### PR TITLE
Define path to TypeScript types in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -167,7 +167,7 @@
     "steal-mocha": "^2.0.1",
     "testee": "^0.9.0",
     "ts-node": "^8.0.3",
-    "typescript": "^3.4.1",
+    "typescript": "^3.7.2",
     "vue": "^2.6.10",
     "vuepress": "^1.0.2",
     "vuex": "^3.1.0"

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "homepage": "https:feathers-vuex.feathers-plus.com",
   "main": "dist/",
   "module": "dist/",
-  "types": "dist/",
+  "types": "src/",
   "keywords": [
     "feathers",
     "feathers-plugin"

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "homepage": "https:feathers-vuex.feathers-plus.com",
   "main": "dist/",
   "module": "dist/",
+  "types": "dist/",
   "keywords": [
     "feathers",
     "feathers-plugin"

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "homepage": "https:feathers-vuex.feathers-plus.com",
   "main": "dist/",
   "module": "dist/",
-  "types": "src/",
+  "types": "dist/",
   "keywords": [
     "feathers",
     "feathers-plugin"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,7 @@
     "esModuleInterop": true,
     "outDir": "dist",
     "moduleResolution": "node",
+    "declaration": true,
     "target": "es6",
     "sourceMap": false
   },


### PR DESCRIPTION
This pull request enables TypeScript declarations and adds a reference to them in `package.json`. It essentially prevents seeing a warning when attempting to pull in the package from a TypeScript file. This also enables the TypeScript type hinting we all have come to love. 🎉

![image](https://user-images.githubusercontent.com/4034561/68542915-8b5a3780-03b9-11ea-93c8-c6b813abace7.png)


