### PR TITLE
test(package.json): Fix glob pattern in mocha test script

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "watch": "shx rm -rf lib/ && babel --watch -d lib/ src/",
     "lint": "standard --fix",
     "coverage": "istanbul cover node_modules/mocha/bin/_mocha -- --opts mocha.opts",
-    "test": "TS_NODE_PROJECT='tsconfig.test.json' mocha --require ts-node/register test/**/*.test.ts",
+    "test": "TS_NODE_PROJECT='tsconfig.test.json' mocha --require ts-node/register 'test/**/*.test.ts'",
     "testee": "testee test/index.html --browsers firefox",
     "start": "npm run compile && node example/app",
     "docs:serve": "vuepress dev docs",


### PR DESCRIPTION
The test script in the package.json should have the glob pattern wrapped in single quotes like mentioned here: [https://mochajs.org/#the-test-directory](https://mochajs.org/#the-test-directory)

> You should always quote your globs in npm scripts. If you use double quotes, it's the shell on UNIX that will expand the glob. On the other hand, if you use single quotes, the node-glob module will handle its expansion.

If not, in some environments it will not take the files in the root directory into accounts.