### PR TITLE
improvement(mixin): keep the find method available even when the local option is set, fix #394, 

### DIFF
--- a/src/make-get-mixin.ts
+++ b/src/make-get-mixin.ts
@@ -120,12 +120,11 @@ export default function makeFindMixin(options) {
     },
     // add the created lifecycle hook only if local option is falsy
     ...(!local && {
-      created: function created() {
-        debug &&
+      created() {
+        if (debug) {
           console.log(
             `running 'created' hook in makeGetMixin for service "${service}" (using name ${nameToUse}")`
           )
-        if (debug) {
           console.log(ID, this[ID])
           console.log(PARAMS, this[PARAMS])
           console.log(FETCH_PARAMS, this[FETCH_PARAMS])

--- a/src/make-get-mixin.ts
+++ b/src/make-get-mixin.ts
@@ -95,75 +95,78 @@ export default function makeFindMixin(options) {
         const paramsToUse = params || this[FETCH_PARAMS] || this[PARAMS]
         const idToUse = id || this[ID]
 
-        if (!this[LOCAL]) {
-          if (this[QUERY_WHEN]) {
-            this[IS_GET_PENDING] = true
-            this[HAS_ITEM_BEEN_REQUESTED_ONCE] = true
+        if (this[QUERY_WHEN]) {
+          this[IS_GET_PENDING] = true
+          this[HAS_ITEM_BEEN_REQUESTED_ONCE] = true
 
-            if (idToUse != null) {
-              return this.$store
-                .dispatch(`${this[SERVICE_NAME]}/get`, [idToUse, paramsToUse])
-                .then(response => {
-                  // To prevent thrashing, only clear ERROR on response, not on initial request.
-                  this[ERROR] = null
+          if (idToUse != null) {
+            return this.$store
+              .dispatch(`${this[SERVICE_NAME]}/get`, [idToUse, paramsToUse])
+              .then(response => {
+                // To prevent thrashing, only clear ERROR on response, not on initial request.
+                this[ERROR] = null
 
-                  this[HAS_ITEM_LOADED_ONCE] = true
-                  this[IS_GET_PENDING] = false
-                  return response
-                })
-                .catch(error => {
-                  this[ERROR] = error
-                  return error
-                })
-            }
+                this[HAS_ITEM_LOADED_ONCE] = true
+                this[IS_GET_PENDING] = false
+                return response
+              })
+              .catch(error => {
+                this[ERROR] = error
+                return error
+              })
           }
         }
       }
     },
-    created() {
-      debug &&
-        console.log(
-          `running 'created' hook in makeGetMixin for service "${service}" (using name ${nameToUse}")`
-        )
-      debug && console.log(ID, this[ID])
-      debug && console.log(PARAMS, this[PARAMS])
-      debug && console.log(FETCH_PARAMS, this[FETCH_PARAMS])
-
-      const pType = Object.getPrototypeOf(this)
-
-      if (
-        this.hasOwnProperty(ID) ||
-        pType.hasOwnProperty(ID) ||
-        pType.hasOwnProperty(PARAMS) ||
-        pType.hasOwnProperty(FETCH_PARAMS)
-      ) {
-        if (!watch.includes(ID)) {
-          watch.push(ID)
+    // add the created lifecycle hook only if local option is falsy
+    ...(!local && {
+      created: function created() {
+        debug &&
+          console.log(
+            `running 'created' hook in makeGetMixin for service "${service}" (using name ${nameToUse}")`
+          )
+        if (debug) {
+          console.log(ID, this[ID])
+          console.log(PARAMS, this[PARAMS])
+          console.log(FETCH_PARAMS, this[FETCH_PARAMS])
         }
 
-        watch.forEach(prop => {
-          if (typeof prop !== 'string') {
-            throw new Error(`Values in the 'watch' array must be strings.`)
-          }
-          prop = prop.replace('query', PARAMS)
+        const pType = Object.getPrototypeOf(this)
 
-          if (pType.hasOwnProperty(FETCH_PARAMS)) {
-            if (prop.startsWith(PARAMS)) {
-              prop.replace(PARAMS, FETCH_PARAMS)
+        if (
+          this.hasOwnProperty(ID) ||
+          pType.hasOwnProperty(ID) ||
+          pType.hasOwnProperty(PARAMS) ||
+          pType.hasOwnProperty(FETCH_PARAMS)
+        ) {
+          if (!watch.includes(ID)) {
+            watch.push(ID)
+          }
+
+          watch.forEach(prop => {
+            if (typeof prop !== 'string') {
+              throw new Error(`Values in the 'watch' array must be strings.`)
             }
-          }
-          this.$watch(prop, function () {
-            return this[GET_ACTION]()
-          })
-        })
+            prop = prop.replace('query', PARAMS)
 
-        return this[GET_ACTION]()
-      } else {
-        console.log(
-          `No "${ID}", "${PARAMS}" or "${FETCH_PARAMS}" attribute was found in the makeGetMixin for the "${service}" service (using name "${nameToUse}").  No queries will be made.`
-        )
+            if (pType.hasOwnProperty(FETCH_PARAMS)) {
+              if (prop.startsWith(PARAMS)) {
+                prop.replace(PARAMS, FETCH_PARAMS)
+              }
+            }
+            this.$watch(prop, function() {
+              return this[GET_ACTION]()
+            })
+          })
+
+          return this[GET_ACTION]()
+        } else {
+          console.log(
+            `No "${ID}", "${PARAMS}" or "${FETCH_PARAMS}" attribute was found in the makeGetMixin for the "${service}" service (using name "${nameToUse}").  No queries will be made.`
+          )
+        }
       }
-    }
+    })
   }
 
   function hasSomeAttribute(vm, ...attributes) {

--- a/test/make-find-mixin.test.ts
+++ b/test/make-find-mixin.test.ts
@@ -44,7 +44,6 @@ describe('Find Mixin', function() {
 
   it('correctly forms mixin data', function() {
     const todosMixin = makeFindMixin({ service: 'todos' })
-    // todosMixin.
     interface TodosComponent {
       todos: []
       todosServiceName: string

--- a/test/make-find-mixin.test.ts
+++ b/test/make-find-mixin.test.ts
@@ -3,13 +3,13 @@ eslint
 @typescript-eslint/explicit-function-return-type: 0,
 @typescript-eslint/no-explicit-any: 0
 */
-import jsdom from 'jsdom-global'
 import { assert } from 'chai'
-import feathersVuex, { FeathersVuex } from '../src/index'
-import { feathersRestClient as feathersClient } from './fixtures/feathers-client'
-import makeFindMixin from '../src/make-find-mixin'
+import jsdom from 'jsdom-global'
 import Vue from 'vue/dist/vue'
 import Vuex from 'vuex'
+import feathersVuex, { FeathersVuex } from '../src/index'
+import makeFindMixin from '../src/make-find-mixin'
+import { feathersRestClient as feathersClient } from './fixtures/feathers-client'
 
 jsdom()
 require('events').EventEmitter.prototype._maxListeners = 100
@@ -44,7 +44,7 @@ describe('Find Mixin', function() {
 
   it('correctly forms mixin data', function() {
     const todosMixin = makeFindMixin({ service: 'todos' })
-
+    // todosMixin.
     interface TodosComponent {
       todos: []
       todosServiceName: string
@@ -81,6 +81,10 @@ describe('Find Mixin', function() {
     assert(typeof vm.findTodos === 'function', 'the find action is in place')
     assert(vm.todosLocal === false, 'local boolean is false by default')
     assert(
+      typeof vm.$options.created[0] === 'function',
+      'created lifecycle hook function is in place given that local is false'
+    )
+    assert(
       vm.todosQid === 'default',
       'the default query identifier is in place'
     )
@@ -96,11 +100,12 @@ describe('Find Mixin', function() {
     )
   })
 
-  it.skip('correctly forms mixin data for dynamic service', function() {
+  it('correctly forms mixin data for dynamic service', function() {
     const tasksMixin = makeFindMixin({
       service() {
         return this.serviceName
-      }
+      },
+      local: true
     })
 
     interface TasksComponent {
@@ -116,7 +121,7 @@ describe('Find Mixin', function() {
     }
 
     const vm = new Vue({
-      name: 'tasls-component',
+      name: 'tasks-component',
       data: () => ({
         serviceName: 'tasks'
       }),
@@ -125,27 +130,31 @@ describe('Find Mixin', function() {
       template: `<div></div>`
     }).$mount()
 
-    assert.deepEqual(vm.tasks, [], 'tasks prop was empty array')
+    assert.deepEqual(vm.items, [], 'items prop was empty array')
     assert(
-      vm.hasOwnProperty('tasksPaginationData'),
+      vm.hasOwnProperty('servicePaginationData'),
       'pagination data prop was present, even if undefined'
     )
-    assert(vm.tasksServiceName === 'tasks', 'service name was correct')
-    assert(vm.isFindTasksPending === false, 'loading boolean is in place')
-    assert(typeof vm.findTasks === 'function', 'the find action is in place')
-    assert(vm.tasksLocal === false, 'local boolean is false by default')
+    assert(vm.serviceServiceName === 'tasks', 'service name was correct')
+    assert(vm.isFindServicePending === false, 'loading boolean is in place')
+    assert(typeof vm.findService === 'function', 'the find action is in place')
+    assert(vm.serviceLocal === true, 'local boolean is set to true')
     assert(
-      vm.tasksQid === 'default',
+      typeof vm.$options.created === 'undefined',
+      'created lifecycle hook function is NOT in place given that local is true'
+    )
+    assert(
+      vm.serviceQid === 'default',
       'the default query identifier is in place'
     )
-    assert(vm.tasksQueryWhen() === true, 'the default queryWhen is true')
+    assert(vm.serviceQueryWhen === true, 'the default queryWhen is true')
     // assert(vm.tasksWatch.length === 0, 'the default watch is an empty array')
     assert(
-      vm.tasksParams === undefined,
+      vm.serviceParams === undefined,
       'no params are in place by default, must be specified by the user'
     )
     assert(
-      vm.tasksFetchParams === undefined,
+      vm.serviceFetchParams === undefined,
       'no fetch params are in place by default, must be specified by the user'
     )
   })


### PR DESCRIPTION
This pull request fix #394 

To resume, in the mixins, the local option make the mixin not fetch records on the created hook but still gives access to the getter and items.

But it also prevent the use of the find method.
So in order to make a request you need to use the vuex store directly.

This PR lets you set the mixin as local but still have access to the find mixin for a later use.
In addition it makes the mixin a bit more lightweight as the entire created hook is added conditionally.

In order to not introduce a breaking change, the watch option is still ineffective when the local option is set.

In the future, it might be interesting to modify this behavior by letting the watch option works even if the local option is set.
Thus, the local option could be renamed to something like "fetchOnCreated".

This PR also fix [the test for the dynamic service name](https://github.com/feathersjs-ecosystem/feathers-vuex/blob/14c8305acbb182d5ce52eb9b8b75ac38964360d2/test/make-find-mixin.test.ts#L99) that was previously skipped. 
 