### PR TITLE
Use find params

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,6 +102,9 @@
   "directories": {
     "lib": "lib"
   },
+  "peerDependencies": {
+    "@vue/composition-api": "^0.3.4"
+  },
   "dependencies": {
     "@feathersjs/adapter-commons": "^4.4.3",
     "@feathersjs/commons": "^4.4.3",
@@ -110,7 +113,6 @@
     "@types/inflection": "^1.5.28",
     "@types/lodash": "^4.14.149",
     "@types/npm": "^2.0.31",
-    "@vue/composition-api": "^0.3.4",
     "bson-objectid": "^1.3.0",
     "debug": "^4.1.1",
     "events": "^3.1.0",
@@ -141,6 +143,7 @@
     "@types/mocha": "^5.2.7",
     "@typescript-eslint/eslint-plugin": "^2.16.0",
     "@typescript-eslint/parser": "^2.16.0",
+    "@vue/composition-api": "^0.3.4",
     "@vue/eslint-config-prettier": "^6.0.0",
     "@vue/eslint-config-typescript": "^5.0.1",
     "@vue/test-utils": "^1.0.0-beta.30",

--- a/test/use/find.test.ts
+++ b/test/use/find.test.ts
@@ -106,6 +106,65 @@ describe('use/find', function() {
     assert(qid.value === 'default')
   })
 
+  it('returns correct default data even when params is not reactive', function() {
+    const { Instrument } = makeContext()
+
+    const instrumentsData = useFind({
+      model: Instrument,
+      params: {
+        query: {},
+        paginate: false
+      }
+    })
+
+    const {
+      debounceTime,
+      error,
+      haveBeenRequested,
+      haveLoaded,
+      isPending,
+      isLocal,
+      items,
+      latestQuery,
+      paginationData,
+      qid
+    } = instrumentsData
+
+    assert(isRef(debounceTime))
+    assert(debounceTime.value === null)
+
+    assert(isRef(error))
+    assert(error.value === null)
+
+    assert(isRef(haveBeenRequested))
+    assert(haveBeenRequested.value === true)
+
+    assert(isRef(haveLoaded))
+    assert(haveLoaded.value === false)
+
+    assert(isRef(isPending))
+    assert(isPending.value === true)
+
+    assert(isRef(isLocal))
+    assert(isLocal.value === false)
+
+    assert(isRef(items))
+    assert(Array.isArray(items.value))
+    assert(items.value.length === 0)
+
+    assert(isRef(latestQuery))
+    assert(latestQuery.value === null)
+
+    assert(isRef(paginationData))
+    assert.deepStrictEqual(paginationData.value, {
+      defaultLimit: null,
+      defaultSkip: null
+    })
+
+    assert(isRef(qid))
+    assert(qid.value === 'default')
+  })
+
   it('allows passing {lazy:true} to not query immediately', function() {
     const { Instrument } = makeContext()
 


### PR DESCRIPTION
Fixes #413 

Also moves the Vue Composition API plugin into `peerDependencies` to prevent having two versions in the dependency tree of a project.