### PR TITLE
Allow simple data modification in clone

### DIFF
--- a/src/service-module/make-base-model.ts
+++ b/src/service-module/make-base-model.ts
@@ -266,7 +266,7 @@ export default function makeBaseModel(options: FeathersVuexOptions) {
       return this._clone(id, data)
     }
 
-    private _clone(id, data) {
+    private _clone(id, data = {}) {
       const { store, namespace, _commit, _getters } = this
         .constructor as typeof BaseModel
       const { keepCopiesInStore } = store.state[namespace]
@@ -274,10 +274,10 @@ export default function makeBaseModel(options: FeathersVuexOptions) {
       _commit.call(this.constructor, `createCopy`, id)
 
       if (keepCopiesInStore) {
-        return Object.assign(_getters.call(this.constructor, 'getCopyById', id), data || {})
+        return Object.assign(_getters.call(this.constructor, 'getCopyById', id), data)
       } else {
         // const { copiesById } = this.constructor as typeof BaseModel
-        return Object.assign((this.constructor as typeof BaseModel).copiesById[id], data || {})
+        return Object.assign((this.constructor as typeof BaseModel).copiesById[id], data)
       }
     }
     /**

--- a/src/service-module/make-base-model.ts
+++ b/src/service-module/make-base-model.ts
@@ -256,17 +256,17 @@ export default function makeBaseModel(options: FeathersVuexOptions) {
     /**
      * clone the current record using the `createCopy` mutation
      */
-    public clone() {
+    public clone(data) {
       const { idField, tempIdField } = this.constructor as typeof BaseModel
       if (this.__isClone) {
         throw new Error('You cannot clone a copy')
       }
       const id =
         getId(this, idField) != null ? getId(this, idField) : this[tempIdField]
-      return this._clone(id)
+      return this._clone(id, data)
     }
 
-    private _clone(id) {
+    private _clone(id, data) {
       const { store, namespace, _commit, _getters } = this
         .constructor as typeof BaseModel
       const { keepCopiesInStore } = store.state[namespace]
@@ -274,10 +274,10 @@ export default function makeBaseModel(options: FeathersVuexOptions) {
       _commit.call(this.constructor, `createCopy`, id)
 
       if (keepCopiesInStore) {
-        return _getters.call(this.constructor, 'getCopyById', id)
+        return Object.assign(_getters.call(this.constructor, 'getCopyById', id), data || {})
       } else {
         // const { copiesById } = this.constructor as typeof BaseModel
-        return (this.constructor as typeof BaseModel).copiesById[id]
+        return Object.assign((this.constructor as typeof BaseModel).copiesById[id], data || {})
       }
     }
     /**

--- a/test/service-module/service-module.test.ts
+++ b/test/service-module/service-module.test.ts
@@ -387,6 +387,25 @@ describe('Service Module', function() {
       )
     })
 
+    it(`allows shallow assign of data when cloning`, function() {
+      const { serviceTodo, owners } = this
+      let serviceTodoClone = serviceTodo.clone({ isComplete: !serviceTodo.isComplete })
+
+      assert.equal(
+        !serviceTodo.isComplete,
+        serviceTodoClone.isComplete,
+        'clone value has changed'
+      )
+
+      serviceTodoClone.commit()
+
+      assert.equal(
+        serviceTodo.isComplete,
+        true,
+        'value has changed after commit'
+      )
+    })
+
     it('allows reseting copy changes back to match the original', function() {
       const { serviceTodo } = this
       let serviceTodoClone = serviceTodo.clone()


### PR DESCRIPTION
## Summary

### Tell us about the problem your pull request is solving.
This allows a simple one-liner `user.clone({ enabled: !user.enabled }).save()`

### Are there any open issues that are related to this?
nope

### Is this PR dependent on PRs in other repos?
nope

### Should this go in the docs
Maybe, this won't account for errors and is probably not the recommended way to go about changes. But it would be a nice hack for power users ;)

