### PR TITLE
Added check for getterParams is not undefined, to enable documented "…

### DIFF
--- a/src/useFind.ts
+++ b/src/useFind.ts
@@ -97,7 +97,7 @@ export default function find(options: UseFindOptions): UseFindData {
     items: computed<any[]>(() => {
       const getterParams = unwrapParams(params)
 
-      if (getterParams.paginate) {
+      if (getterParams && getterParams.paginate) {
         const serviceState = model.store.state[model.servicePath]
         const { defaultSkip, defaultLimit } = serviceState.pagination
         const skip = getterParams.query.$skip || defaultSkip


### PR DESCRIPTION
…return null" feature

Added check for getterParams is not undefined, to enable documented "return null" feature as described in https://vuex.feathersjs.com/composition-api.html#options (before returning null in the computed threw an error because paginate couldn't be found on a null object)