### PR TITLE
Update Full nuxt example in common-patterns.md to fix middleware redirect

### DIFF
--- a/docs/common-patterns.md
+++ b/docs/common-patterns.md
@@ -550,9 +550,9 @@ The `feathers` middleware will redirect any user in a non public page to the log
 export default function ({ store, redirect, route }) {
   const { auth } = store.state
   if (auth.publicPages.length > 0 && !auth.publicPages.includes(route.name) && !auth.payload) {
-    return redirect('login')
+    return redirect('/login')
   } else if (auth.publicPages.length > 0 && auth.publicPages.includes(route.name) && auth.payload) {
-    return redirect('feed')
+    return redirect('/feed')
   }
 }
 ```


### PR DESCRIPTION
### Summary

(If you have not already please refer to the contributing guideline as [described
here](https://github.com/feathersjs/feathers/blob/master/.github/contributing.md#pull-requests))

- [x] Tell us about the problem your pull request is solving. the current example causes the rediect to `http://login/` but it should actually just redirect to the page `/login`.
- [x] Are there any open issues that are related to this? no
- [x] Is this PR dependent on PRs in other repos? no
