### PR TITLE
Correct issue with service name comparison in auth responseHandler()

### DIFF
--- a/src/auth-module/auth-module.actions.ts
+++ b/src/auth-module/auth-module.actions.ts
@@ -4,6 +4,7 @@ eslint
 @typescript-eslint/no-explicit-any: 0
 */
 import { globalModels as models } from '../service-module/global-models'
+import { getShortName } from '../utils'
 
 export default function makeAuthActions(feathersClient) {
   return {
@@ -38,7 +39,7 @@ export default function makeAuthActions(feathersClient) {
           if (state.serverAlias && state.userService) {
             const Model = Object.keys(models[state.serverAlias])
               .map(modelName => models[state.serverAlias][modelName])
-              .find(model => model.servicePath === state.userService)
+              .find(model => model.servicePath === getShortName(state.userService))
             if (Model) {
               user = new Model(user)
             }

--- a/src/auth-module/auth-module.actions.ts
+++ b/src/auth-module/auth-module.actions.ts
@@ -39,7 +39,7 @@ export default function makeAuthActions(feathersClient) {
           if (state.serverAlias && state.userService) {
             const Model = Object.keys(models[state.serverAlias])
               .map(modelName => models[state.serverAlias][modelName])
-              .find(model => model.servicePath === getShortName(state.userService))
+              .find(model => getShortName(model.servicePath) === getShortName(state.userService))
             if (Model) {
               user = new Model(user)
             }

--- a/src/auth-module/auth-module.actions.ts
+++ b/src/auth-module/auth-module.actions.ts
@@ -4,7 +4,7 @@ eslint
 @typescript-eslint/no-explicit-any: 0
 */
 import { globalModels as models } from '../service-module/global-models'
-import { getShortName } from '../utils'
+import { getNameFromPath } from '../utils'
 
 export default function makeAuthActions(feathersClient) {
   return {
@@ -39,7 +39,7 @@ export default function makeAuthActions(feathersClient) {
           if (state.serverAlias && state.userService) {
             const Model = Object.keys(models[state.serverAlias])
               .map(modelName => models[state.serverAlias][modelName])
-              .find(model => getShortName(model.servicePath) === getShortName(state.userService))
+              .find(model => getNameFromPath(model.servicePath) === getNameFromPath(state.userService))
             if (Model) {
               user = new Model(user)
             }


### PR DESCRIPTION
This pull request addresses an issue with the authentication `responseHandler()` where models with service paths that include a leading or trailing slash won't match with the configured `userService` for the Authentication module. This will in turn result in the `auth` `isAuthenticated` getter always showing up as `false` until the user is manually retrieved from the database. Even though the WebSockets session is authenticated and the `user` state is correctly populated.

#### Tl;dr:
A `Users` model defined with service path `/users` and `makeAuthPlugin` with `{ usersService: 'users' }` would result in FeathersVuex thinking the user is not logged in even though they are. In addition to not populating the `auth/user` getter. This pull request resolves that. 👌