### PR TITLE
improvement(service-module.getters): improve "get" getter

### DIFF
--- a/src/service-module/service-module.getters.ts
+++ b/src/service-module/service-module.getters.ts
@@ -69,15 +69,16 @@ export default function makeServiceGetters() {
         data: values
       }
     },
-    get: state => (id, params = {}) => {
-      const { keyedById, tempsById, idField, tempIdField } = state
-      const record = keyedById[id]
-        ? select(params, idField)(keyedById[id])
-        : undefined
-      const tempRecord = tempsById[id]
-        ? select(params, tempIdField)(tempsById[id])
-        : undefined
-      return record || tempRecord || null
+    get: ({ keyedById, tempsById, idField, tempIdField }) =>
+      (id, params = {}) => {
+        const record = keyedById[id] && select(params, idField)(keyedById[id]);
+        if (record) {
+          return record;
+        }
+        const tempRecord = 
+          tempsById[id] && select(params, tempIdField)(tempsById[id]);
+
+        return tempRecord || null;
     },
     getCopyById: state => id => {
       const { servicePath, keepCopiesInStore, serverAlias } = state


### PR DESCRIPTION
- Apply destructuring directly on arguments
- Only call select on "tempsById" if record is undefined and return record early otherwise
- Convert ternary to "short-circuiting"