### PR TITLE
Temp clone management

### DIFF
--- a/src/service-module/make-base-model.ts
+++ b/src/service-module/make-base-model.ts
@@ -185,11 +185,7 @@ export default function makeBaseModel(options: FeathersVuexOptions) {
     }
 
     public static getFromStore(id, params?) {
-      if (params) {
-        return this._getters('get', id, params)
-      } else {
-        return this._getters('get', id)
-      }
+      return this._getters('get', id, params)
     }
 
     /**

--- a/src/service-module/service-module.actions.ts
+++ b/src/service-module/service-module.actions.ts
@@ -322,7 +322,7 @@ export default function makeServiceActions(service: Service<any>) {
         service.FeathersVuexModel &&
         !(item instanceof service.FeathersVuexModel)
       ) {
-        item = new service.FeathersVuexModel(item)
+        item = new service.FeathersVuexModel(item, { commit: false })
       }
 
       // If the item has a matching temp, update the temp and provide it as the new item.

--- a/src/service-module/service-module.actions.ts
+++ b/src/service-module/service-module.actions.ts
@@ -318,7 +318,10 @@ export default function makeServiceActions(service: Service<any>) {
 
       const isIdOk = id !== null && id !== undefined
 
-      if (service.FeathersVuexModel && !item.isFeathersVuexInstance) {
+      if (
+        service.FeathersVuexModel &&
+        !(item instanceof service.FeathersVuexModel)
+      ) {
         item = new service.FeathersVuexModel(item)
       }
 

--- a/src/service-module/service-module.actions.ts
+++ b/src/service-module/service-module.actions.ts
@@ -312,7 +312,6 @@ export default function makeServiceActions(service: Service<any>) {
     addOrUpdate({ state, commit }, item) {
       const { idField } = state
       const id = getId(item, idField)
-      const existingItem = state.keyedById[id]
 
       const isIdOk = id !== null && id !== undefined
 
@@ -323,22 +322,14 @@ export default function makeServiceActions(service: Service<any>) {
         item = new service.FeathersVuexModel(item, { commit: false })
       }
 
-      // If the item has a matching temp, update the temp and provide it as the new item.
-      const temp = state.tempsByNewId[id]
-      if (temp) {
-        commit('merge', { dest: temp, source: item })
-        commit('remove__isTemp', temp)
-      }
       if (isIdOk) {
-        if (existingItem && temp) {
-          commit('replaceItemWithTemp', { item, temp })
+        if (state.keyedById[id]) {
+          commit('updateItem', item)
         } else {
-          existingItem
-            ? commit('updateItem', temp || item)
-            : commit('addItem', temp || item)
+          commit('addItem', item)
         }
       }
-      return temp || item
+      return item
     }
   }
   /**

--- a/src/service-module/service-module.actions.ts
+++ b/src/service-module/service-module.actions.ts
@@ -292,9 +292,7 @@ export default function makeServiceActions(service: Service<any>) {
 
       if (service.FeathersVuexModel) {
         toAdd.forEach((item, index) => {
-          toAdd[index] = new service.FeathersVuexModel(item, {
-            skipCommit: true
-          })
+          toAdd[index] = new service.FeathersVuexModel(item, { commit: false })
         })
       }
 

--- a/src/service-module/service-module.actions.ts
+++ b/src/service-module/service-module.actions.ts
@@ -51,7 +51,7 @@ export default function makeServiceActions(service: Service<any>) {
         return service
           .get(id, params)
           .then(async function(item) {
-            await dispatch('addOrUpdate', item)
+            dispatch('addOrUpdate', item)
             commit('unsetPending', 'get')
             return state.keyedById[id]
           })
@@ -99,7 +99,7 @@ export default function makeServiceActions(service: Service<any>) {
         .create(data, params)
         .then(async response => {
           if (Array.isArray(response)) {
-            await dispatch('addOrUpdateList', response)
+            dispatch('addOrUpdateList', response)
             response = response.map(item => {
               const id = getId(item, idField)
 
@@ -112,7 +112,7 @@ export default function makeServiceActions(service: Service<any>) {
             if (id != null && tempId != null) {
               commit('updateTemp', { id, tempId })
             }
-            response = await dispatch('addOrUpdate', response)
+            response = dispatch('addOrUpdate', response)
 
             // response = state.keyedById[id]
           }
@@ -135,7 +135,7 @@ export default function makeServiceActions(service: Service<any>) {
       return service
         .update(id, data, params)
         .then(async function(item) {
-          await dispatch('addOrUpdate', item)
+          dispatch('addOrUpdate', item)
           commit('unsetPending', 'update')
           return state.keyedById[id]
         })
@@ -165,7 +165,7 @@ export default function makeServiceActions(service: Service<any>) {
       return service
         .patch(id, data, params)
         .then(async function(item) {
-          await dispatch('addOrUpdate', item)
+          dispatch('addOrUpdate', item)
           commit('unsetPending', 'patch')
           return state.keyedById[id]
         })
@@ -223,7 +223,7 @@ export default function makeServiceActions(service: Service<any>) {
       const { qid = 'default', query } = params
       const { idField } = state
 
-      await dispatch('addOrUpdateList', response)
+      dispatch('addOrUpdateList', response)
       commit('unsetPending', 'find')
 
       const mapItemFromState = item => {
@@ -260,7 +260,7 @@ export default function makeServiceActions(service: Service<any>) {
       return response
     },
 
-    async addOrUpdateList({ state, commit }, response) {
+    addOrUpdateList({ state, commit }, response) {
       const list = response.data || response
       const isPaginated = response.hasOwnProperty('total')
       const toAdd = []
@@ -311,7 +311,7 @@ export default function makeServiceActions(service: Service<any>) {
      * the `create` response returns to create the record. The reference to the
      * original temporary record must be maintained in order to preserve reactivity.
      */
-    async addOrUpdate({ state, commit }, item) {
+    addOrUpdate({ state, commit }, item) {
       const { idField } = state
       const id = getId(item, idField)
       const existingItem = state.keyedById[id]

--- a/src/service-module/service-module.getters.ts
+++ b/src/service-module/service-module.getters.ts
@@ -9,7 +9,6 @@ import { filterQuery, sorter, select } from '@feathersjs/adapter-commons'
 import { globalModels as models } from './global-models'
 import _get from 'lodash/get'
 import _omit from 'lodash/omit'
-import _unionBy from 'lodash/unionBy'
 
 const FILTERS = ['$sort', '$limit', '$skip', '$select']
 const OPERATORS = ['$in', '$nin', '$lt', '$lte', '$gt', '$gte', '$ne', '$or']
@@ -27,7 +26,7 @@ export default function makeServiceGetters() {
       // Set params.temps to true to include the tempsById records
       params.temps = params.hasOwnProperty('temps') ? params.temps : false
 
-      const { paramsForServer, whitelist, idField, tempIdField } = state
+      const { paramsForServer, whitelist, keyedById } = state
       const q = _omit(params.query || {}, paramsForServer)
       const customOperators = Object.keys(q).filter(
         k => k[0] === '$' && !defaultOps.includes(k)
@@ -37,14 +36,10 @@ export default function makeServiceGetters() {
       const { query, filters } = filterQuery(cleanQuery, {
         operators: additionalOperators.concat(whitelist)
       })
-      let values = _.values(state.keyedById)
+      let values = _.values(keyedById)
 
       if (params.temps) {
-        values = _unionBy(
-          values,
-          _.values(state.tempsById),
-          i => i[tempIdField] || i[idField]
-        )
+        values = values.concat(_.values(state.tempsById))
       }
 
       values = values.filter(sift(query))

--- a/src/service-module/service-module.mutations.ts
+++ b/src/service-module/service-module.mutations.ts
@@ -21,7 +21,7 @@ export default function makeServiceMutations() {
   function addItems(state, items) {
     const { serverAlias, idField, tempIdField, modelName } = state
     const Model = _get(models, `[${serverAlias}][${modelName}]`)
-    const BaseModel = _get(models, `[${state.serverAlias}].BaseModel`)
+    const BaseModel = _get(models, `[${serverAlias}].BaseModel`)
 
     for (let item of items) {
       const id = getId(item, idField)
@@ -159,8 +159,18 @@ export default function makeServiceMutations() {
       }
     },
 
-    remove__isTemp(state, temp) {
+    remove__isTemp({ modelName, serverAlias, tempIdField }, temp) {
       Vue.delete(temp, '__isTemp')
+
+      // Remove from temp's clone as well if it exists
+      const tempId = temp[tempIdField]
+      if (tempId) {
+        const Model = _get(models, `[${serverAlias}][${modelName}]`)
+        const tempClone = Model && Model.copiesById && Model.copiesById[tempId]
+        if (tempClone) {
+          Vue.delete(tempClone, '__isTemp')
+        }
+      }
     },
 
     removeItem(state, item) {

--- a/src/service-module/service-module.mutations.ts
+++ b/src/service-module/service-module.mutations.ts
@@ -90,9 +90,10 @@ export default function makeServiceMutations() {
               !(item instanceof Model)
             ) {
               item = new Model(item)
+            } else {
+              const original = state.keyedById[id]
+              updateOriginal(original, item)
             }
-            const original = state.keyedById[id]
-            updateOriginal(original, item)
           }
 
           // if addOnUpsert then add the record into the state, else discard it.

--- a/src/service-module/service-module.mutations.ts
+++ b/src/service-module/service-module.mutations.ts
@@ -138,8 +138,10 @@ export default function makeServiceMutations() {
       updateItems(state, items)
     },
 
-    // Adds an _id to a temp record so that that the addOrUpdate action
-    // can migrate the temp to the keyedById state.
+    // Promotes temp to "real" item:
+    // - adds _id to temp
+    // - removes __isTemp flag
+    // - migrates temp from tempsById to keyedById
     updateTemp(state, { id, tempId }) {
       const temp = state.tempsById[tempId]
       if (temp) {

--- a/src/service-module/service-module.mutations.ts
+++ b/src/service-module/service-module.mutations.ts
@@ -145,6 +145,14 @@ export default function makeServiceMutations() {
         temp[state.idField] = id
         state.tempsByNewId[id] = temp
       }
+
+      // Add _id to temp's clone as well if it exists
+      const Model = _get(models, `[${state.serverAlias}][${state.modelName}]`)
+      const tempClone = Model && Model.copiesById && Model.copiesById[tempId]
+      if (tempClone) {
+        tempClone[state.idField] = id
+        Model.copiesById[id] = tempClone
+      }
     },
 
     /**

--- a/src/service-module/service-module.mutations.ts
+++ b/src/service-module/service-module.mutations.ts
@@ -71,7 +71,7 @@ export default function makeServiceMutations() {
         if (state.ids.includes(id)) {
           // Completely replace the item
           if (replaceItems) {
-            if (Model && !item.isFeathersVuexInstance) {
+            if (Model && !(item instanceof Model)) {
               item = new Model(item)
             }
             Vue.set(state.keyedById, id, item)

--- a/src/service-module/service-module.state.ts
+++ b/src/service-module/service-module.state.ts
@@ -27,7 +27,6 @@ export interface ServiceStateExclusiveDefaults {
 
   keyedById: {}
   tempsById: {}
-  tempsByNewId: {}
   copiesById: {}
   namespace?: string
   pagination?: {
@@ -57,7 +56,6 @@ export interface ServiceState {
   idField: string
   keyedById: {}
   tempsById: {}
-  tempsByNewId: {}
   copiesById: {}
   whitelist: string[]
   paramsForServer: string[]
@@ -98,7 +96,6 @@ export default function makeDefaultState(options: MakeServicePluginOptions) {
     keyedById: {},
     copiesById: {},
     tempsById: {}, // Really should be called tempsByTempId
-    tempsByNewId: {}, // temporary storage for temps while getting transferred from tempsById to keyedById
     pagination: {
       defaultLimit: null,
       defaultSkip: null

--- a/test/service-module/make-service-plugin.test.ts
+++ b/test/service-module/make-service-plugin.test.ts
@@ -87,7 +87,6 @@ describe('makeServicePlugin', function() {
       servicePath: 'todos',
       skipRequestIfExists: false,
       tempsById: {},
-      tempsByNewId: {},
       whitelist: []
     }
 

--- a/test/service-module/model-temp-ids.test.ts
+++ b/test/service-module/model-temp-ids.test.ts
@@ -373,4 +373,33 @@ describe('Models - Temp Ids', function() {
       })
       .catch(done)
   })
+
+  it('removes __isTemp from temp and clone', function() {
+    const { makeServicePlugin, BaseModel } = feathersVuex(feathersClient, {
+      idField: '_id',
+      serverAlias: 'temp-ids'
+    })
+    class Thing extends BaseModel {
+      public static modelName = 'Thing'
+    }
+    const store = new Vuex.Store<RootState>({
+      plugins: [
+        makeServicePlugin({
+          Model: Thing,
+          service: feathersClient.service('things')
+        })
+      ]
+    })
+
+    const thing = new Thing()
+    assert(thing.__isTemp, 'thing has __isTemp')
+
+    const clone = thing.clone()
+    assert(clone.__isTemp, 'Clone also has __isTemp')
+
+    store.commit('things/remove__isTemp', thing)
+
+    assert(!thing.hasOwnProperty('__isTemp'), '__isTemp was removed from thing')
+    assert(!clone.hasOwnProperty('__isTemp'), '__isTemp was removed from clone')
+  })
 })

--- a/test/service-module/model-temp-ids.test.ts
+++ b/test/service-module/model-temp-ids.test.ts
@@ -180,9 +180,12 @@ describe('Models - Temp Ids', function() {
           },
           context => {
             assert(!context.data.__id, '__id was not sent to API server')
-            assert(!context.data.__id, '__isTemp was not sent to API server')
+            assert(
+              !context.data.__isTemp,
+              '__isTemp was not sent to API server'
+            )
             context.result = {
-              id: 1,
+              _id: 1,
               description: 'Robb Wolf - the Paleo Solution',
               website:
                 'https://robbwolf.com/shop-old/products/the-paleo-solution-the-original-human-diet/',

--- a/test/service-module/service-module.test.ts
+++ b/test/service-module/service-module.test.ts
@@ -658,7 +658,6 @@ describe('Service Module', function() {
         servicePath: 'service-todos',
         tempIdField: '__id',
         tempsById: {},
-        tempsByNewId: {},
         pagination: {
           defaultLimit: null,
           defaultSkip: null


### PR DESCRIPTION
### Summary

I'm working on a simple note taking app that auto-saves after user input. I've ran into some issues with temps and clones not behaving as I expected.

- [x] Tell us about the problem your pull request is solving.
  - Calling `clone.save()` multiple times creates multiple rows in the DB because clones do not get the ID after the first `create`. This can be avoided by re-cloning after `create` succeeds, but that discards any changes to the clone that occur while waiting for the API server's response. So you have to copy modified properties to a temp object, then re-clone. This is tedious and can be avoided by just adding the ID received from the `create` response to the instance's clone.
   - Similar to above, clones keep their `__isTemp` status after successful `create`. This means subsequent calls to `clone.commit()` add `__isTemp` back to the original model instance. I didn't have any major issues with this, but it made debugging more confusing.
  - I am using the `makeFindMixin` to retrieve list items for my notes. When querying with `temps: true`, I briefly get a `Duplicate keys detected ... This may cause update error.` error from Vue after `create` succeeds. This is because my `v-for`'s `key` is bound to the query result's `item.id`. But the real reason is that during the process of moving models from `tempsById` to `keyedById`, `find()` runs again and includes the model from both `tempsById` and `keyedById`. I can avoid this error by just binding the `v-for`'s `key` to the `v-for`'s index, but then I lose reactivity per item. ~The actual issue is that the `addOrUpdate` action is `await`ed when it doesn't need to be `async` at all. This wait causes the `find()` to run in the next tick which finds the model in both places and throws the duplicate keys error before `addOrUpdate` finishes moving the model.~ That only solved my issue because my API server is not sending `created` events back to the client that caused them. So I think a more general solution is to take the union (by ID or temp ID) between `keyedById` and `tempsById` in the find getter when `temps: true`.

- [ ] Are there any open issues that are related to this?
  - no
- [ ] Is this PR dependent on PRs in other repos?
  - no

### Other Information

n/a