### PR TITLE
Fix: Auth module responseHandler modifying state outside of mutation

### DIFF
--- a/src/auth-module/auth-module.actions.ts
+++ b/src/auth-module/auth-module.actions.ts
@@ -3,6 +3,7 @@ eslint
 @typescript-eslint/explicit-function-return-type: 0,
 @typescript-eslint/no-explicit-any: 0
 */
+import fastCopy from 'fast-copy'
 import { globalModels as models } from '../service-module/global-models'
 import { getNameFromPath } from '../utils'
 
@@ -41,7 +42,8 @@ export default function makeAuthActions(feathersClient) {
               .map(modelName => models[state.serverAlias][modelName])
               .find(model => getNameFromPath(model.servicePath) === getNameFromPath(state.userService))
             if (Model) {
-              user = new Model(user)
+              // Copy user object to avoid setupInstance modifying payload state
+              user = new Model(fastCopy(user))
             }
           }
           commit('setUser', user)


### PR DESCRIPTION
### Summary

The `responseHandler` in `auth-module.actions` first sets the entire auth response as `payload` in the auth module state, then if a user was returned and a user Model exists, a new Model is created. If the user Model's `setupInstance` changes the data (e.g. convert datetime to `Date`), then it is actually modifying `payload` state and Vuex throws an error (in `strict` mode).

### Solution

`fastCopy` the user data before creating the Model instance so that `setupInstance` runs on the copy

- [ ] Are there any open issues that are related to this?
no

- [ ] Is this PR dependent on PRs in other repos?
no
