### PR TITLE
fix issue #466 (Bug: FeathersVuexFind component)

### DIFF
--- a/src/FeathersVuexFind.ts
+++ b/src/FeathersVuexFind.ts
@@ -151,7 +151,7 @@ export default {
         }
         if (this.fetchQuery) {
           if (prop.startsWith('query')) {
-            prop.replace('query', 'fetchQuery')
+            prop = prop.replace('query', 'fetchQuery')
           }
         }
         this.$watch(prop, this.fetchData)


### PR DESCRIPTION
### Summary
issue #466 

Bug in the component [FeathersVuexFind](https://vuex.feathersjs.com/data-components.html#feathersvuexfind)

There was a problem with the watch property who was watching query, even a fetchQuery was provided. This was due to the method replace() which return a new string, and not change the string ([mdn js doc](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replace)).

It's fix. Thank you !
