### PR TITLE
fix: don't overwrite handleEvents handlers #472

### DIFF
--- a/src/service-module/make-service-plugin.ts
+++ b/src/service-module/make-service-plugin.ts
@@ -64,7 +64,7 @@ export default function prepareMakeServicePlugin(
     } = options
 
     events.forEach(eventName => {
-      if (options.handleEvents[eventName])
+      if (!options.handleEvents[eventName])
         options.handleEvents[eventName] = () => options.enableEvents || true
     })
 

--- a/src/service-module/make-service-plugin.ts
+++ b/src/service-module/make-service-plugin.ts
@@ -63,6 +63,14 @@ export default function prepareMakeServicePlugin(
       preferUpdate
     } = options
 
+    if (globalOptions.handleEvents && options.handleEvents) {
+      options.handleEvents = Object.assign(
+        {},
+        globalOptions.handleEvents,
+        options.handleEvents
+      )
+    }
+
     events.forEach(eventName => {
       if (!options.handleEvents[eventName])
         options.handleEvents[eventName] = () => options.enableEvents || true

--- a/test/service-module/make-service-plugin.test.ts
+++ b/test/service-module/make-service-plugin.test.ts
@@ -138,4 +138,203 @@ describe('makeServicePlugin', function() {
     assert(models[serverAlias][Todo.name] === Todo)
     assert(Todo.store === store)
   })
+
+  it('allows service specific handleEvents', async function() {
+    // feathers.use('todos', new TodosService())
+    const serverAlias = 'default'
+    const { makeServicePlugin, BaseModel } = feathersVuex(feathers, {
+      idField: '_id',
+      serverAlias
+    })
+
+    const servicePath = 'todos'
+    class Todo extends BaseModel {
+      public static modelName = 'Todo'
+      public static servicePath = servicePath
+    }
+
+    let createdCalled = false
+    let updatedCalled = false
+    let patchedCalled = false
+    let removedCalled = false
+    const todosPlugin = makeServicePlugin({
+      servicePath,
+      Model: Todo,
+      service: feathers.service(servicePath),
+      handleEvents: {
+        created() {
+          createdCalled = true
+          return true
+        },
+        updated() {
+          updatedCalled = true
+          return true
+        },
+        patched() {
+          patchedCalled = true
+          return true
+        },
+        removed() {
+          removedCalled = true
+          return true
+        }
+      }
+    })
+
+    const store = new Vuex.Store({
+      plugins: [todosPlugin]
+    })
+
+    const todo = new Todo()
+
+    // Fake server call
+    feathers.service('todos').hooks({
+      before: {
+        create: [
+          context => {
+            delete context.data.__id
+            delete context.data.__isTemp
+          },
+          context => {
+            context.result = { _id: 24, ...context.data }
+            return context
+          }
+        ],
+        update: [
+          context => {
+            context.result = { ...context.data }
+            return context
+          }
+        ],
+        patch: [
+          context => {
+            context.result = { ...context.data }
+            return context
+          }
+        ],
+        remove: [
+          context => {
+            context.result = { ...todo }
+            return context
+          }
+        ]
+      }
+    })
+
+    await todo.create()
+    assert(createdCalled, 'created handler called')
+
+    await todo.update()
+    assert(updatedCalled, 'updated handler called')
+
+    await todo.patch()
+    assert(patchedCalled, 'patched handler called')
+
+    await todo.remove()
+    assert(removedCalled, 'removed handler called')
+  })
+
+  it('fall back to globalOptions handleEvents if service specific handleEvents handler is missing', async function() {
+    // feathers.use('todos', new TodosService())
+    const serverAlias = 'default'
+
+    let globalCreatedCalled = false
+    let globalUpdatedCalled = false
+    let globalPatchedCalled = false
+    let globalRemovedCalled = false
+    const { makeServicePlugin, BaseModel } = feathersVuex(feathers, {
+      idField: '_id',
+      serverAlias,
+      handleEvents: {
+        created() {
+          globalCreatedCalled = true
+          return true
+        },
+        updated() {
+          globalUpdatedCalled = true
+          return true
+        },
+        patched() {
+          globalPatchedCalled = true
+          return true
+        },
+        removed() {
+          globalRemovedCalled = true
+          return true
+        }
+      }
+    })
+
+    const servicePath = 'todos'
+    class Todo extends BaseModel {
+      public static modelName = 'Todo'
+      public static servicePath = servicePath
+    }
+
+    let specificUpdatedCalled = false
+    const todosPlugin = makeServicePlugin({
+      servicePath,
+      Model: Todo,
+      service: feathers.service(servicePath),
+      handleEvents: {
+        updated() {
+          specificUpdatedCalled = true
+          return true
+        }
+      }
+    })
+
+    const store = new Vuex.Store({
+      plugins: [todosPlugin]
+    })
+
+    const todo = new Todo()
+
+    // Fake server call
+    feathers.service('todos').hooks({
+      before: {
+        create: [
+          context => {
+            delete context.data.__id
+            delete context.data.__isTemp
+          },
+          context => {
+            context.result = { _id: 24, ...context.data }
+            return context
+          }
+        ],
+        update: [
+          context => {
+            context.result = { ...context.data }
+            return context
+          }
+        ],
+        patch: [
+          context => {
+            context.result = { ...context.data }
+            return context
+          }
+        ],
+        remove: [
+          context => {
+            context.result = { ...todo }
+            return context
+          }
+        ]
+      }
+    })
+
+    await todo.create()
+    assert(globalCreatedCalled, 'global created handler called')
+
+    await todo.update()
+    assert(specificUpdatedCalled, 'specific updated handler called')
+    assert(!globalUpdatedCalled, 'global updated handler NOT called')
+
+    await todo.patch()
+    assert(globalPatchedCalled, 'global patched handler called')
+
+    await todo.remove()
+    assert(globalRemovedCalled, 'global removed handler called')
+  })
 })


### PR DESCRIPTION
### Summary

`handleEvents` handlers were being overwritten. See #472 .

- [x] Tell us about the problem your pull request is solving.
- [x] Are there any open issues that are related to this?
  -  #472 
- [x] Is this PR dependent on PRs in other repos?
  - no

### Other Information

I also added falling back to any globally configured `handleEvents` handlers if configured. This will allow services to have specific `handleEvents` handlers for only some instead of all events and then fall back to an app-wide implementation (if one is provided) for the other events.
