### PR TITLE
feature: allow passing auth params

### DIFF
--- a/src/auth-module/auth-module.actions.ts
+++ b/src/auth-module/auth-module.actions.ts
@@ -11,14 +11,9 @@ export default function makeAuthActions(feathersClient) {
   return {
     authenticate(store, dataOrArray) {
       const { commit, state, dispatch } = store
-      let data
-      let params
-      if (Array.isArray(dataOrArray)) {
-        data = dataOrArray[0]
-        params = dataOrArray[1]
-      } else {
-        data = dataOrArray
-      }
+      const [data, params] = Array.isArray(dataOrArray)
+        ? dataOrArray
+        : [dataOrArray]
 
       commit('setAuthenticatePending')
       if (state.errorOnAuthenticate) {

--- a/src/auth-module/auth-module.actions.ts
+++ b/src/auth-module/auth-module.actions.ts
@@ -9,15 +9,23 @@ import { getNameFromPath } from '../utils'
 
 export default function makeAuthActions(feathersClient) {
   return {
-    authenticate(store, data) {
+    authenticate(store, dataOrArray) {
       const { commit, state, dispatch } = store
+      let data
+      let params
+      if (Array.isArray(dataOrArray)) {
+        data = dataOrArray[0]
+        params = dataOrArray[1]
+      } else {
+        data = dataOrArray
+      }
 
       commit('setAuthenticatePending')
       if (state.errorOnAuthenticate) {
         commit('clearAuthenticateError')
       }
       return feathersClient
-        .authenticate(data)
+        .authenticate(data, params)
         .then(response => {
           return dispatch('responseHandler', response)
         })


### PR DESCRIPTION
### Summary

Allow passing `params` to `feathers.authenticate()` via auth module `authenticate` action.

- [x] Tell us about the problem your pull request is solving.
- [x] Are there any open issues that are related to this?
  - no
- [x] Is this PR dependent on PRs in other repos?
  - no

### Other Information

Should this be mentioned in the docs?