### PR TITLE
feature: handle complex events

### DIFF
--- a/src/service-module/make-service-plugin.ts
+++ b/src/service-module/make-service-plugin.ts
@@ -64,7 +64,7 @@ export default function prepareMakeServicePlugin(
     } = options
 
     events.forEach(eventName => {
-      if (options.handleEvents[eventName])
+      if (!options.handleEvents[eventName])
         options.handleEvents[eventName] = () => options.enableEvents || true
     })
 

--- a/src/service-module/make-service-plugin.ts
+++ b/src/service-module/make-service-plugin.ts
@@ -117,14 +117,18 @@ export default function prepareMakeServicePlugin(
       // (3^) Setup real-time events
       if (options.enableEvents) {
         const handleEvent = (eventName, item, mutationName) => {
-          const affectsStore = options.handleEvents[eventName](item, {
+          const handler = options.handleEvents[eventName]
+          const confirmOrArray = handler(item, {
             model: Model,
             models: globalModels
           })
+          const [affectsStore, modified = item] = Array.isArray(confirmOrArray)
+            ? confirmOrArray
+            : [confirmOrArray]
           if (affectsStore) {
             eventName === 'removed'
-              ? store.commit(`${options.namespace}/removeItem`, item)
-              : store.dispatch(`${options.namespace}/${mutationName}`, item)
+              ? store.commit(`${options.namespace}/removeItem`, modified)
+              : store.dispatch(`${options.namespace}/${mutationName}`, modified)
           }
         }
 

--- a/src/service-module/make-service-plugin.ts
+++ b/src/service-module/make-service-plugin.ts
@@ -63,6 +63,14 @@ export default function prepareMakeServicePlugin(
       preferUpdate
     } = options
 
+    if (globalOptions.handleEvents && options.handleEvents) {
+      options.handleEvents = Object.assign(
+        {},
+        globalOptions.handleEvents,
+        options.handleEvents
+      )
+    }
+
     events.forEach(eventName => {
       if (!options.handleEvents[eventName])
         options.handleEvents[eventName] = () => options.enableEvents || true

--- a/test/service-module/make-service-plugin.test.ts
+++ b/test/service-module/make-service-plugin.test.ts
@@ -138,4 +138,203 @@ describe('makeServicePlugin', function() {
     assert(models[serverAlias][Todo.name] === Todo)
     assert(Todo.store === store)
   })
+
+  it('allows service specific handleEvents', async function() {
+    // feathers.use('todos', new TodosService())
+    const serverAlias = 'default'
+    const { makeServicePlugin, BaseModel } = feathersVuex(feathers, {
+      idField: '_id',
+      serverAlias
+    })
+
+    const servicePath = 'todos'
+    class Todo extends BaseModel {
+      public static modelName = 'Todo'
+      public static servicePath = servicePath
+    }
+
+    let createdCalled = false
+    let updatedCalled = false
+    let patchedCalled = false
+    let removedCalled = false
+    const todosPlugin = makeServicePlugin({
+      servicePath,
+      Model: Todo,
+      service: feathers.service(servicePath),
+      handleEvents: {
+        created() {
+          createdCalled = true
+          return true
+        },
+        updated() {
+          updatedCalled = true
+          return true
+        },
+        patched() {
+          patchedCalled = true
+          return true
+        },
+        removed() {
+          removedCalled = true
+          return true
+        }
+      }
+    })
+
+    const store = new Vuex.Store({
+      plugins: [todosPlugin]
+    })
+
+    const todo = new Todo()
+
+    // Fake server call
+    feathers.service('todos').hooks({
+      before: {
+        create: [
+          context => {
+            delete context.data.__id
+            delete context.data.__isTemp
+          },
+          context => {
+            context.result = { _id: 24, ...context.data }
+            return context
+          }
+        ],
+        update: [
+          context => {
+            context.result = { ...context.data }
+            return context
+          }
+        ],
+        patch: [
+          context => {
+            context.result = { ...context.data }
+            return context
+          }
+        ],
+        remove: [
+          context => {
+            context.result = { ...todo }
+            return context
+          }
+        ]
+      }
+    })
+
+    await todo.create()
+    assert(createdCalled, 'created handler called')
+
+    await todo.update()
+    assert(updatedCalled, 'updated handler called')
+
+    await todo.patch()
+    assert(patchedCalled, 'patched handler called')
+
+    await todo.remove()
+    assert(removedCalled, 'removed handler called')
+  })
+
+  it('fall back to globalOptions handleEvents if service specific handleEvents handler is missing', async function() {
+    // feathers.use('todos', new TodosService())
+    const serverAlias = 'default'
+
+    let globalCreatedCalled = false
+    let globalUpdatedCalled = false
+    let globalPatchedCalled = false
+    let globalRemovedCalled = false
+    const { makeServicePlugin, BaseModel } = feathersVuex(feathers, {
+      idField: '_id',
+      serverAlias,
+      handleEvents: {
+        created() {
+          globalCreatedCalled = true
+          return true
+        },
+        updated() {
+          globalUpdatedCalled = true
+          return true
+        },
+        patched() {
+          globalPatchedCalled = true
+          return true
+        },
+        removed() {
+          globalRemovedCalled = true
+          return true
+        }
+      }
+    })
+
+    const servicePath = 'todos'
+    class Todo extends BaseModel {
+      public static modelName = 'Todo'
+      public static servicePath = servicePath
+    }
+
+    let specificUpdatedCalled = false
+    const todosPlugin = makeServicePlugin({
+      servicePath,
+      Model: Todo,
+      service: feathers.service(servicePath),
+      handleEvents: {
+        updated() {
+          specificUpdatedCalled = true
+          return true
+        }
+      }
+    })
+
+    const store = new Vuex.Store({
+      plugins: [todosPlugin]
+    })
+
+    const todo = new Todo()
+
+    // Fake server call
+    feathers.service('todos').hooks({
+      before: {
+        create: [
+          context => {
+            delete context.data.__id
+            delete context.data.__isTemp
+          },
+          context => {
+            context.result = { _id: 24, ...context.data }
+            return context
+          }
+        ],
+        update: [
+          context => {
+            context.result = { ...context.data }
+            return context
+          }
+        ],
+        patch: [
+          context => {
+            context.result = { ...context.data }
+            return context
+          }
+        ],
+        remove: [
+          context => {
+            context.result = { ...todo }
+            return context
+          }
+        ]
+      }
+    })
+
+    await todo.create()
+    assert(globalCreatedCalled, 'global created handler called')
+
+    await todo.update()
+    assert(specificUpdatedCalled, 'specific updated handler called')
+    assert(!globalUpdatedCalled, 'global updated handler NOT called')
+
+    await todo.patch()
+    assert(globalPatchedCalled, 'global patched handler called')
+
+    await todo.remove()
+    assert(globalRemovedCalled, 'global removed handler called')
+  })
 })


### PR DESCRIPTION
### Summary

In my application, I would like to pass extra information with service events from the API server (e.g. who caused the event, what device they're on, etc.) so that when data changes, a component can indicate to the user that the content was modified by user Foo or by device "Bar's IPhone". Currently, this is not really workable as the entire event data is passed to the `addOrUpdate` or `removeItem` actions. I could modify the event data directly in a `handleEvents` handler, but this would also change what data is passed to `Model.emit()` and therefore defeat the purpose of passing event source/context with the event to components listening with `Model.on()`.

My proposal is to allow the `handleEvents` handler to somehow modify what data is dispatched to actions, but still pass the entire event data to `Model.emit()`.

I originally thought about just returning the object to dispatch but did not want to deal with discerning what values for `affectsStore` are truthy and what values should actually be dispatched. Instead, my implementation allows returning a tuple `[affectsStore, dataToDispatch]` where `affectsStore` behaves exactly as it does now (can be truthy), and `dataToDispatch` is the data to dispatch to actions. To preserve current functionality and not make this a breaking change, if an array is not returned from the handler, the value is used for `affectsStore` and the original item is dispatched.

### Other Information

- [x] Tell us about the problem your pull request is solving.
- [x] Are there any open issues that are related to this?
  - no
- [x] Is this PR dependent on PRs in other repos?
  - this PR depends and is based on #473 in this repo
  - if accepted, this would need an update in the docs repo. I will submit a PR there once I receive feedback on this PR.
