### PR TITLE
Fix service plugin in SSR setups (do not preserve model/module state if reinitialized)

### DIFF
--- a/test/service-module/service-module.reinitialization.test.ts
+++ b/test/service-module/service-module.reinitialization.test.ts
@@ -1,0 +1,149 @@
+import { assert } from 'chai'
+import Vuex from 'vuex'
+import { feathersRestClient as feathersClient } from '../fixtures/feathers-client'
+import feathersVuex from '../../src/index'
+
+interface RootState {
+  todos: any
+}
+
+function makeContext() {
+  const todoService = feathersClient.service('todos')
+  const serverAlias = 'reinitialization'
+  const { makeServicePlugin, BaseModel, models } = feathersVuex(
+    feathersClient,
+    {
+      serverAlias
+    }
+  )
+  class Todo extends BaseModel {
+    public static modelName = 'Todo'
+  }
+  return {
+    makeServicePlugin,
+    BaseModel,
+    todoService,
+    Todo,
+    models,
+    serverAlias
+  }
+}
+
+describe('Service Module - Reinitialization', function() {
+  /**
+   * Tests that when the make service plugin is reinitialized state
+   * is reset in the vuex module/model.
+   * This prevents state pollution in SSR setups.
+   */
+  it('does not preserve module/model state when reinitialized', function() {
+    const {
+      makeServicePlugin,
+      todoService,
+      Todo,
+      models,
+      serverAlias
+    } = makeContext()
+    const todosPlugin = makeServicePlugin({
+      servicePath: 'todos',
+      Model: Todo,
+      service: todoService
+    })
+    let store = new Vuex.Store<RootState>({
+      plugins: [todosPlugin]
+    })
+    let todoState = store.state['todos']
+    const virginState = {
+      addOnUpsert: false,
+      autoRemove: false,
+      debug: false,
+      copiesById: {},
+      enableEvents: true,
+      errorOnCreate: null,
+      errorOnFind: null,
+      errorOnGet: null,
+      errorOnPatch: null,
+      errorOnRemove: null,
+      errorOnUpdate: null,
+      idField: 'id',
+      tempIdField: '__id',
+      ids: [],
+      isCreatePending: false,
+      isFindPending: false,
+      isGetPending: false,
+      isPatchPending: false,
+      isRemovePending: false,
+      isUpdatePending: false,
+      keepCopiesInStore: false,
+      keyedById: {},
+      modelName: 'Todo',
+      nameStyle: 'short',
+      namespace: 'todos',
+      pagination: {
+        defaultLimit: null,
+        defaultSkip: null
+      },
+      paramsForServer: [],
+      preferUpdate: false,
+      replaceItems: false,
+      serverAlias,
+      servicePath: 'todos',
+      skipRequestIfExists: false,
+      tempsById: {},
+      whitelist: []
+    }
+
+    assert.deepEqual(
+      todoState,
+      virginState,
+      'vuex module state is correct on first initialization'
+    )
+    assert.deepEqual(
+      models[serverAlias][Todo.name].store.state[Todo.namespace],
+      todoState,
+      'model state is the same as vuex module state on first initialization'
+    )
+
+    // Simulate some mutations on the store.
+    const todo = {
+      id: 1,
+      testProp: true
+    }
+
+    store.commit('todos/addItem', todo)
+    const serviceTodo = store.state['todos'].keyedById[1]
+
+    assert.equal(
+      todo.testProp,
+      serviceTodo.testProp,
+      'todo is added to the store'
+    )
+
+    assert.deepEqual(
+      models[serverAlias][Todo.name].store.state[Todo.namespace],
+      todoState,
+      'model state is the same as vuex module state when store is mutated'
+    )
+
+    // Here we are going to simulate the make service plugin being reinitialized.
+    // This is the default behaviour in SSR setups, e.g. nuxt universal mode,
+    // although unlikely in SPAs.
+    store = new Vuex.Store<RootState>({
+      plugins: [todosPlugin]
+    })
+
+    todoState = store.state['todos']
+
+    // We expect vuex module state for this service to be reset.
+    assert.deepEqual(
+      todoState,
+      virginState,
+      'store state in vuex module is not preserved on reinitialization'
+    )
+    // We also expect model store state for this service to be reset.
+    assert.deepEqual(
+      models[serverAlias][Todo.name].store.state[Todo.namespace],
+      virginState,
+      'store state in service model is not preserved on reinitialization'
+    )
+  })
+})


### PR DESCRIPTION
### Summary

- [ ] Tell us about the problem your pull request is solving.

The service module doesn't work as expected if it's reinitialized, which happens on each request in SSR setups (only once in SPAs). The cause of this issue is an inconsistency between how module and model state is preserved when the service plugin is reinitialized.

This PR fixes this issue and opts for a default behavior of _not preserving state_ if a service plugin is reinitialized. This makes the behavior compatible with the majority of SSR setups where state is reset between each request (i.e. to prevent state pollution/memory leaks).

- [ ] Are there any open issues that are related to this?
https://github.com/feathersjs-ecosystem/feathers-vuex/issues/470
- [ ] Is this PR dependent on PRs in other repos?
No
If so, please mention them to keep the conversations linked together.

### Other Information

If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

Your PR will be reviewed by a core team member and they will work with you to get your changes merged in a timely manner. If merged your PR will automatically be added to the changelog in the next release.

If your changes involve documentation updates please mention that and link the appropriate PR in [feathers-docs](https://github.com/feathersjs/feathers-docs).

Thanks for contributing to Feathers! :heart: