### PR TITLE
fix: diffOnPatch

### DIFF
--- a/src/service-module/service-module.actions.ts
+++ b/src/service-module/service-module.actions.ts
@@ -155,7 +155,7 @@ export default function makeServiceActions(service: Service<any>) {
 
       params = fastCopy(params)
 
-      if (service.FeathersVuexModel && params && !params.data) {
+      if (service.FeathersVuexModel && (!params || !params.data)) {
         data = service.FeathersVuexModel.diffOnPatch(data)
       }
       if (params && params.data) {


### PR DESCRIPTION
Since v3.9.0 the diffOnPatch is not fired when `params` is not defined. This little change should fix this.