### PR TITLE
fix: add temp's id to `ids` in `updateTemp` #489

### DIFF
--- a/src/service-module/service-module.mutations.ts
+++ b/src/service-module/service-module.mutations.ts
@@ -151,6 +151,10 @@ export default function makeServiceMutations() {
         // If an item already exists in the store from the `created` event firing
         // it will be replaced here
         Vue.set(state.keyedById, id, temp)
+        // Only add the id if it's not already in the `ids` list.
+        if (!state.ids.includes(id)) {
+          state.ids.push(id)
+        }
       }
 
       // Add _id to temp's clone as well if it exists

--- a/test/service-module/model-temp-ids.test.ts
+++ b/test/service-module/model-temp-ids.test.ts
@@ -431,6 +431,7 @@ describe('Models - Temp Ids', function() {
     store.commit('things/updateTemp', { id: 42, tempId: thing.__id })
     assert(thing._id === 42, 'thing got _id')
     assert(store.state.things.keyedById[42] === thing, 'thing is in keyedById')
+    assert(store.state.things.ids.includes(42), "thing's _id is in ids")
     assert(
       !store.state.things.tempsById[thing.__id],
       'thing is no longer in tempsById'

--- a/test/service-module/types.ts
+++ b/test/service-module/types.ts
@@ -5,7 +5,7 @@ eslint
 */
 export interface ServiceState {
   options: {}
-  ids: string[]
+  ids: (string | number)[]
   autoRemove: boolean
   errorOnFind: any
   errorOnGet: any


### PR DESCRIPTION
### Summary

When promoting a temp to a "real" item, the `updateTemp` mutation migrates a temp from `tempsById` to `keyedById`. It was not also adding the new ID to the `ids` array.

This PR adds the new ID to `ids` and adds a test assertion to verify.

- [x] Tell us about the problem your pull request is solving.
- [x] Are there any open issues that are related to this?
  - #489 
- [x] Is this PR dependent on PRs in other repos?
  - no

### Other Information

I changed the type of `ids` from `string[]` to `(string | number)[]` so the test could use `Array.includes` with the ID of type `number`. Ids can already be `string` or a `number`.