### PR TITLE
fix: useGet lazy

### DIFF
--- a/docs/composition-api.md
+++ b/docs/composition-api.md
@@ -281,7 +281,7 @@ And here's a look at each individual property:
 - `params` is a FeathersJS Params object OR a Composition API `ref` (or `computed`, since they return a `ref` instance) which returns a Params object.
   - Unlike the `useFind` utility, `useGet` does not currently have built-in debouncing.
 - `queryWhen` must be a `computed` property which returns a `boolean`. It provides a logical separation for preventing API requests apart from `null` in the `id`.
-- `lazy`, which is `true` by default, determines if the internal `watch` should fire immediately.  By default a single query will be performed, independent of the watchers.  Set `lazy: false` and the watchers on the `id` and `params` will fire immediately (currently this will cause duplicate queries to be performed, so it's not recommended).
+- `lazy`, which is `false` by default, determines if the internal `watch` should fire immediately.  Set `lazy: true` and the query will not fire immediately.  It will only fire on subsequent changes to the `id` or `params`.
 
 ### Returned Attributes
 

--- a/src/useGet.ts
+++ b/src/useGet.ts
@@ -46,7 +46,7 @@ export default function get(options: UseGetOptions): UseGetData {
     params: null,
     queryWhen: computed((): boolean => true),
     local: false,
-    lazy: true
+    lazy: false
   }
   const { model, id, params, queryWhen, local, lazy } = Object.assign(
     {},
@@ -126,10 +126,6 @@ export default function get(options: UseGetOptions): UseGetData {
     },
     { lazy }
   )
-
-  if (lazy) {
-    get(id, getParams())
-  }
 
   return {
     servicePath,

--- a/src/useGet.ts
+++ b/src/useGet.ts
@@ -112,17 +112,12 @@ export default function get(options: UseGetOptions): UseGetData {
     }
   }
 
-  watch(
+  watch([
     () => getId(),
-    id => {
-      get(id, getParams())
-    },
-    { lazy }
-  )
-  watch(
     () => getParams(),
-    params => {
-      get(getId(), params)
+  ],
+    ([id, params]) => {
+      get(id as string | number, params as Params)
     },
     { lazy }
   )

--- a/test/use/get.test.ts
+++ b/test/use/get.test.ts
@@ -130,7 +130,7 @@ describe('use/get', function() {
     const { Instrument } = makeContext()
 
     const id = null
-    const instrumentData = useGet({ model: Instrument, id, lazy: true })
+    const instrumentData = useGet({ model: Instrument, id })
     const { hasBeenRequested } = instrumentData
 
     assert(isRef(hasBeenRequested))


### PR DESCRIPTION
### Summary

3.10.4 broke lazy behavior with `useGet`. This was a workaround to prevent duplicate queries due to both watchers firing. This PR reverts the commit that broke lazy behavior and combines watchers into one so the API is only hit once on initial render.

- [x] Tell us about the problem your pull request is solving.
- [x] Are there any open issues that are related to this?
  - no
- [x] Is this PR dependent on PRs in other repos?
  - no

### Other Information

This PR also fixes a minor bug in the `useGet` tests where the scenario `id === null` prevents an API query. The test was also passing `lazy: true` which means the null ID was not definitely preventing the API query - it could have been prevented by `lazy: true`.