### PR TITLE
fix: addItems calls new Model calls addItem

### DIFF
--- a/src/service-module/service-module.mutations.ts
+++ b/src/service-module/service-module.mutations.ts
@@ -33,7 +33,7 @@ export default function makeServiceMutations() {
       }
 
       if (Model && !(item instanceof BaseModel) && !(item instanceof Model)) {
-        item = new Model(item)
+        item = new Model(item, { commit: false })
       }
 
       if (isTemp) {


### PR DESCRIPTION
There's a loop between mutations & Model for creating models.
When you call `addItems` for completely new data, it calls `new Model` which commits `addItem` which calls `new Model` which commits `mergeInstance`