### PR TITLE
fix:  make createElement compatible with 1.0.0 of @vue/composition-api

### DIFF
--- a/src/FeathersVuexPagination.ts
+++ b/src/FeathersVuexPagination.ts
@@ -1,4 +1,20 @@
-import { createElement, computed, watch } from '@vue/composition-api'
+import {
+  // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
+  // @ts-ignore
+  createElement as baseCreateElement,
+  // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
+  // @ts-ignore
+  h,
+  computed,
+  watch
+} from '@vue/composition-api'
+import { CreateElement } from 'vue'
+
+/**
+ * Allow for usage with newer (^1.0.0) @vue/composition-api releases
+ * See: https://github.com/feathersjs-ecosystem/feathers-vuex/issues/504
+ */
+const createElement = (baseCreateElement || h) as CreateElement
 
 export default {
   name: 'FeathersVuexPagination',


### PR DESCRIPTION
### Summary

This PR allows the usage of @vue/composition-api v1.0.0 and below as a peer dependency by dynamically using either `createElement` or `h`, whichever exists.

- [x] Tell us about the problem your pull request is solving.
- [x] Are there any open issues that are related to this?
#504 
- [x] Is this PR dependent on PRs in other repos?
no

### Other Information

I am not sure if this requires a documentation update or integration testing.