### PR TITLE
Fixed bug in require.context

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -245,7 +245,7 @@ const requireModule = require.context(
   // Whether to look in subfolders
   false,
   // Only include .js files (prevents duplicate imports`)
-  /.js$/
+  /\.js$/
 )
 const servicePlugins = requireModule
   .keys()


### PR DESCRIPTION
By not escaping the period, it has lead to multiple imports of files in my own projects, causing duplicated service errors. The proposed change ensures that `require.context` will only look at `.js` or `.ts` files.