### PR TITLE
Count - Getter/Action, Model methods & renderless data component v3.11.0

### DIFF
--- a/docs/3.0-major-release.md
+++ b/docs/3.0-major-release.md
@@ -84,7 +84,7 @@ This behavior exactly matches the new `useFind` utility.
 
 ## Deprecations
 
-### The `keepCopiesInStore` Option<Badge text="deprecated" type="warning"/>
+### The `keepCopiesInStore` Option <Badge text="deprecated" type="warning"/>
 
 The `keepCopiesInStore` option is now deprecated.  This was a part of the "clone and commit" API which basically disabled the reason for creating the "clone and commit" API in the first place.
 
@@ -92,6 +92,10 @@ If you're not familiar with the Feathers-Vuex "clone and commit" API, you can le
 
 The `keepCopiesInStore` feature is set to be removed in Feathers-Vuex 4.0.
 
-### Auth Plugin State: `user`<Badge text="deprecated" type="warning"/>
+### Auth Plugin State: `user` <Badge text="deprecated" type="warning"/>
 
 As described, earlier on this page, since the Auth Plugin's `user` state is no longer reactive and has been replaced by a `user` getter that IS reactive, the `user` state will be removed in the Feathers-Vuex 4.0.
+
+### Renderless Data Components: `query`, `fetchQuery` and `temps` <Badge text="deprecated type="warning">
+
+To keep consistency with mixins and the composition API it's preferred to use `params` and `fetchParams` instead of the old `query` and `fetchQuery` for renderless data components. Also the `:temps="true"` is deprecated in favour of `:params="{ query: {}, temps: true }"`. This way additional params can be passed to the server if you need some more magic like `$populateParams`.

--- a/docs/data-components.md
+++ b/docs/data-components.md
@@ -12,8 +12,8 @@ Here's what it looks like to use the new component:
 
 ```html
 <template>
-  <FeathersVuexFind service="categories" :query="{}" watch="query">
-    <section class="admin-categories" slot-scope="{ items: categories }">
+  <FeathersVuexFind v-slot="{ items: categories }" service="categories" :query="{}" watch="query">
+    <section class="admin-categories">
       {{categories}}
     </section>
   </FeathersVuexFind>
@@ -67,8 +67,8 @@ export default {
 The `FeathersVuexFind` component retrieves data from the API server, puts it in the Vuex store, then transparently retrieves the live, reactive data from the store and displays it to the user.
 
 ```vue
-<FeathersVuexFind service="users" :query="{}" watch="query">
-  <section slot-scope="{ items: users }">
+<FeathersVuexFind v-slot="{ items: users }" service="users" :query="{}" watch="query">
+  <section>
     {{users}}
   </section>
 </FeathersVuexFind>
@@ -85,10 +85,8 @@ The `FeathersVuexGet` component allows fetching data from directly inside a temp
 
 ```html
 <template>
-  <FeathersVuexGet service="users" :id="id" :params="params" :watch="[id, params]">
-    <template slot-scope="{ item: user }">
+  <FeathersVuexGet v-slot="{ item: user }" service="users" :id="id" :params="params" :watch="[id, params]">
       {{ user }}
-    </template>
   </FeathersVuexGet>
 </template>
 
@@ -163,8 +161,8 @@ The `<FeathersVuexGet>` component has these unique props.
 When using these components, the scope data will become available to the first element nested inside the `FeathersVuexFind` or `FeathersVuexGet` tags.  It's accessible using the `scope-data="props"` attribute:
 
 ```html
-<FeathersVuexFind service="categories" :query="{}">
-  <div slot-scope="props">
+<FeathersVuexFind v-slot="props" service="categories" :query="{}">
+  <div>
     {{props.items}}
   </div>
 </FeathersVuexFind>
@@ -187,11 +185,11 @@ It's also possible to modify the scope data by passing a function as the `edit-s
 
 ### Destructuring props
 
-Use the object destructuring syntax to pull specific variables out of the `slot-scope` object.  In the following example, instead of using `slot-scope="props"`, it directly accesses the `items` prop through destructuring:
+Use the object destructuring syntax to pull specific variables out of the `slot-scope` object.  In the following example, instead of using `v-slot="props"`, it directly accesses the `items` prop through destructuring:
 
 ```html
-<FeathersVuexFind service="categories" :query="{}">
-  <div slot-scope="{ items }">
+<FeathersVuexFind v-slot="{ items }" service="categories" :query="{}">
+  <div>
     {{items}}
   </div>
 </FeathersVuexFind>
@@ -202,8 +200,8 @@ Use the object destructuring syntax to pull specific variables out of the `slot-
 You can also rename scope props through the Object destructuring syntax.  The  `slot-scope` in the next example shows how to give the items a more-descriptive name:
 
 ```html
-<FeathersVuexFind service="categories" :query="{}">
-  <div slot-scope="{ items: categories }">
+<FeathersVuexFind v-slot="{ items: categories } service="categories" :query="{}">
+  <div>
     {{categories}}
   </div>
 </FeathersVuexFind>
@@ -216,8 +214,8 @@ You can also rename scope props through the Object destructuring syntax.  The  `
 In this example, only the `service` attribute is provided. There is no `query` nor `id` provided, so no queries are made. So `props.items` in this example returns an empty array.
 
 ```html
-<FeathersVuexFind service="todos">
-  <div slot-scope="props">
+<FeathersVuexFind v-slot="props" service="todos">
+  <div>
     {{props.items}}
   </div>
 </FeathersVuexFind>
@@ -228,8 +226,8 @@ In this example, only the `service` attribute is provided. There is no `query` n
 This example fetches data from the API server because a query was provided.  Internally, this same `query` is used for both the `find` action and the `find` getter.  Read other examples to see how to use distinct queries.  Be aware that if you use pagination directives like `$skip` or `$limit`, you must use two queries to get the records you desire.
 
 ```html
-<FeathersVuexFind service="todos" :query="{}">
-  <div slot-scope="props">
+<FeathersVuexFind v-slot="props" service="todos" :query="{}">
+  <div>
     {{props.items}}
   </div>
 </FeathersVuexFind>
@@ -240,8 +238,8 @@ This example fetches data from the API server because a query was provided.  Int
 If you've already pulled a bunch of data from the server, you can use the `local` prop to only query the local data:
 
 ```html
-<FeathersVuexFind service="todos" :query="{}" local>
-  <div slot-scope="props">
+<FeathersVuexFind v-slot="props" service="todos" :query="{}" local>
+  <div>
     {{props.items}}
   </div>
 </FeathersVuexFind>
@@ -253,11 +251,12 @@ Sometimes you want to query new data from the server whenever the query changes.
 
 ```html
 <FeathersVuexFind
+  v-slot="props"
   service="todos"
   :query="{ isComplete: true }"
   watch="query"
 >
-  <div slot-scope="props">
+  <div>
     {{props.items}}
   </div>
 </FeathersVuexFind>
@@ -267,11 +266,12 @@ This next example watches a single prop from the query:
 
 ```html
 <FeathersVuexFind
+  v-slot="props"
   service="todos"
   :query="{ isComplete: true, dueDate: 'today' }"
   watch="query.dueDate"
 >
-  <div slot-scope="props">
+  <div>
     {{props.items}}
   </div>
 </FeathersVuexFind>
@@ -281,11 +281,12 @@ You can also provide an array of strings to watch multiple properties:
 
 ```html
 <FeathersVuexFind
+  v-slot="props"
   service="dogs"
   :query="{ breed: 'mixed', bites: true, hasWorms: false }"
   :watch="['query.breed', 'query.bites']"
 >
-  <div slot-scope="props">
+  <div>
     {{props.items}}
   </div>
 </FeathersVuexFind>
@@ -298,12 +299,13 @@ In this scenario, the `fetchQuery` is be used to grab a larger dataset from the 
 ```html
 <template>
   <FeathersVuexFind
+    v-slot="{ items: todos }"
     service="todos"
     :query="{ isComplete }"
     :fetchQuery="{ userId }"
     watch="query.userId"
   >
-    <div slot-scope="{ items: todos }">
+    <div>
       {{todos}}
     </div>
   </FeathersVuexFind>
@@ -326,11 +328,12 @@ The `edit-scope` function allows you to modify the scope before passing it down 
 ```html
 <template>
   <FeathersVuexFind
+    v-slot="{ parentCategories, categoriesByParent }"
     service="categories"
     :query="{}"
     :edit-scope="prepareCategories"
   >
-    <ul slot-scope="{ parentCategories, categoriesByParent }">
+    <ul>
       <li v-for="parent in parentCategories" :key="parent._id">
         <p>{{parent.name}}</p>
         <ul>
@@ -367,12 +370,13 @@ When you want to use server-side pagination you need to pass the ids from the se
 ```html
 <template>
   <FeathersVuexFind
+    v-slot="{ items: todos }"
     :service="service"
     :query="internalQuery"
     :fetch-query="fetchQuery"
     :edit-scope="getPaginationInfo"
   >
-    <div slot-scope="{ items: todos }">
+    <div>
       {{todos}}
     </div>
   </FeathersVuexFind>
@@ -429,15 +433,13 @@ Sometimes you only want to query the API server when certain conditions are met.
     <input type="text" v-model="userSearch"/>
 
     <FeathersVuexFind
+      v-slot="{ items: users, isFindPending: areUsersLoading }"
       service="users"
       :query="usersQuery"
       watch="query"
       :queryWhen="userSearch.length > 2"
     >
-      <ul
-        slot-scope="{ items: users, isFindPending: areUsersLoading }"
-        :class="[ areUsersLoading && 'is-loading' ]"
-      >
+      <ul :class="[ areUsersLoading && 'is-loading' ]">
         <li v-for="user in users" :key="user._id">
           {{user.email}}
         </li>
@@ -469,10 +471,11 @@ You can perform `get` requests with the `FeathersVuexGet` component and its `id`
 
 ```html
 <FeathersVuexGet
+  v-slot="{ item: currentUser, isGetPending }"
   service="todos"
   :id="selectedUserId"
 >
-  <div slot-scope="{ item: currentUser, isGetPending }">
+  <div>
     <div v-if="isGetPending" class="loading"> loading... </div>
     {{currentUser}}
   </div>

--- a/docs/data-components.md
+++ b/docs/data-components.md
@@ -5,7 +5,7 @@ sidebarDepth: 3
 
 # Renderless Data Components
 
-There are two new renderless data provider components: `<FeathersVuexFind>` and `<FeathersVuexGet>`. They simplify performing queries against the store and/or the API server. They make the data available inside each component's default slot.
+There are three renderless data provider components: `<FeathersVuexFind>`, `<FeathersVuexGet>` and `<FeathersVuexCount>`. They simplify performing queries against the store and/or the API server. They make the data available inside each component's default slot.
 
 To see why you might want to use these components, below are two example components that are functionally equivalent.
 
@@ -13,7 +13,12 @@ Here's what it looks like to use the new component:
 
 ```html
 <template>
-  <FeathersVuexFind v-slot="{ items: categories }" service="categories" :params="{ query: {} }" watch="params">
+  <FeathersVuexFind
+    v-slot="{ items: categories }"
+    service="categories"
+    :params="{ query: {} }"
+    watch="params"
+  >
     <section class="admin-categories">
       {{categories}}
     </section>
@@ -70,7 +75,12 @@ The `FeathersVuexFind` component retrieves data from the API server, puts it in 
 ### Example
 
 ```vue
-<FeathersVuexFind v-slot="{ items: users }" service="users" :params="{ query: {} }" watch="query">
+<FeathersVuexFind
+  v-slot="{ items: users }"
+  service="users"
+  :params="{ query: {} }"
+  watch="query"
+>
   <section>
     {{users}}
   </section>
@@ -107,7 +117,13 @@ The `FeathersVuexGet` component allows fetching data from directly inside a temp
 
 ```html
 <template>
-  <FeathersVuexGet v-slot="{ item: user }" service="users" :id="id" :params="params" :watch="[id, params]">
+  <FeathersVuexGet
+    v-slot="{ item: user }"
+    service="users"
+    :id="id"
+    :params="params"
+    :watch="[id, params]"
+  >
       {{ user }}
   </FeathersVuexGet>
 </template>
@@ -156,10 +172,10 @@ The `FeathersVuexCount` component allows displaying a count of records. It makes
 > **Note:** it only works for services with enabled pagination!
 
 ```vue
-<FeathersVuexCount v-slot="{ total }" service="users">
-  <section>
-    {{users}}
-  </section>
+<FeathersVuexCount v-slot="{ total }" service="users" :params="{ query: {} }">
+  <span>
+    {{ total }}
+  </span>
 </FeathersVuexCount>
 ```
 
@@ -205,7 +221,7 @@ Vue.component('FeathersVuexCount', FeathersVuexCount)
 
 ## Scope Data
 
-When using these components, the scope data will become available to the `FeathersVuexFind` or `FeathersVuexGet` tags. It's accessible using the `v-slot="props"` attribute:
+When using these components, the scope data will become available to the `FeathersVuexFind`, `FeathersVuexGet` and `FeathersVuexCount` tags. It's accessible using the `v-slot="props"` attribute:
 
 ```html
 <FeathersVuexFind v-slot="props" service="categories" :params="{ query: {} }">
@@ -214,8 +230,6 @@ When using these components, the scope data will become available to the `Feathe
   </div>
 </FeathersVuexFind>
 ```
-
-By default, the following props are available in the scope data:
 
 It's also possible to modify the scope data by passing a function as the `edit-scope` prop. See the example for [modifying scope data](#Modify-the-scope-data)
 
@@ -236,7 +250,11 @@ Use the object destructuring syntax to pull specific variables out of the `v-slo
 You can also rename scope props through the Object destructuring syntax.  The  `v-slot` in the next example shows how to give the items a more-descriptive name:
 
 ```html
-<FeathersVuexFind v-slot="{ items: categories } service="categories" :params="{ query: {} }"">
+<FeathersVuexFind
+  v-slot="{ items: categories }"
+  service="categories"
+  :params="{ query: {} }"
+>
   <div>
     {{categories}}
   </div>
@@ -245,7 +263,7 @@ You can also rename scope props through the Object destructuring syntax.  The  `
 
 ## Usage Examples
 
-### A basic find all
+#### A basic find all
 
 In this example, only the `service` attribute is provided. There is no `query` nor `id` provided, so no queries are made. So `props.items` in this example returns an empty array.
 
@@ -257,9 +275,9 @@ In this example, only the `service` attribute is provided. There is no `query` n
 </FeathersVuexFind>
 ```
 
-### Fetch data from the API and the same data from the Vuex store
+#### Fetch data from the API and the same data from the Vuex store
 
-This example fetches data from the API server because a query was provided.  Internally, this same `query` is used for both the `find` action and the `find` getter.  Read other examples to see how to use distinct queries.  Be aware that if you use pagination directives like `$skip` or `$limit`, you must use two queries to get the records you desire.
+This example fetches data from the API server because a query was provided.  Internally, this same `query` is used for both the `find` action and the `find` getter. Read other examples to see how to use distinct queries. Be aware that if you use pagination directives like `$skip` or `$limit`, you must use two queries to get the records you desire.
 
 ```html
 <FeathersVuexFind v-slot="props" service="todos" :params="{ query: {} }">
@@ -269,7 +287,7 @@ This example fetches data from the API server because a query was provided.  Int
 </FeathersVuexFind>
 ```
 
-### Only get data from the local Vuex store
+#### Only get data from the local Vuex store
 
 If you've already pulled a bunch of data from the server, you can use the `local` prop to only query the local data:
 
@@ -281,7 +299,7 @@ If you've already pulled a bunch of data from the server, you can use the `local
 </FeathersVuexFind>
 ```
 
-### Watch the query and re-fetch from the API
+#### Watch the query and re-fetch from the API
 
 Sometimes you want to query new data from the server whenever the query changes.  Pass an array of attribute names to the `watch` attribute re-query whenever upon change.  This example watches the entire query object:
 
@@ -328,7 +346,7 @@ You can also provide an array of strings to watch multiple properties:
 </FeathersVuexFind>
 ```
 
-### Use a distinct `params` and `fetchParams`
+#### Use a distinct `params` and `fetchParams`
 
 In this scenario, the `fetchParams` is be used to grab a larger dataset from the API server (all todos with a matching `userId`). The `params` is used by the `find` getter to display a subset of this data from the store.  If the `isComplete` attribute gets set to `true`, only completed todos will be displayed.  Since a `fetchParams` is provided, the `watch` strings will be modified internally to watch the `fetchParams` object.  This means if you are watching `params.query.userId` and you add a `fetchParams`, the component is smart enough to know you meant `fetchParams.query.userId`. You don't have to rewrite your `watch` attribute after adding a `fetchParams` prop.
 
@@ -357,7 +375,7 @@ export default {
 </script>
 ```
 
-### Modify the scope data
+#### Modify the scope data
 
 The `edit-scope` function allows you to modify the scope before passing it down to the default slot.  This feature can be super useful for preparing the data for the template.  The `prepareCategories` method in this next example adds two properties to the scope data, which are used to create a nested category structure:
 
@@ -399,7 +417,7 @@ export default {
 </script>
 ```
 
-### server-side pagination
+#### server-side pagination
 
 When you want to use server-side pagination you need to pass the ids from the server to vuex. It can be done by a combination of `params`, `fetchParams` and `editScope` as described below. The `fetchParams`-prop is only computed after items from the server arrived. The ids for the `find` getter as well as the total amount of available values `total` are extracted by the `edit-scope` function and stored in `data`:
 
@@ -465,7 +483,7 @@ export default {
 </script>
 ```
 
-### Query when certain conditions are met
+#### Query when certain conditions are met
 
 Sometimes you only want to query the API server when certain conditions are met.  This example shows how to query the API server when the `userSearch` has as least three characters.  This property does not affect the internal `find` getter, so the `items` will still update when the `userSearch` property has fewer than three characters, just no API request will be made.  The `isFindPending` attribute is used to indicate when data is being loaded from the server.
 
@@ -509,7 +527,7 @@ export default {
 </script>
 ```
 
-### Use a get request
+#### Use a get request
 
 You can perform `get` requests with the `FeathersVuexGet` component and its `id` property.  In the next example, when the `selectedUserId` changes, a get request will automatically fetch and display the matching user record.  It also shows how to use the `isGetPending` prop to update the UI
 

--- a/docs/data-components.md
+++ b/docs/data-components.md
@@ -1,5 +1,6 @@
 ---
 title: Renderless Data Components
+sidebarDepth: 3
 ---
 
 # Renderless Data Components
@@ -12,7 +13,7 @@ Here's what it looks like to use the new component:
 
 ```html
 <template>
-  <FeathersVuexFind v-slot="{ items: categories }" service="categories" :query="{}" watch="query">
+  <FeathersVuexFind v-slot="{ items: categories }" service="categories" :params="{ query: {} }" watch="params">
     <section class="admin-categories">
       {{categories}}
     </section>
@@ -66,8 +67,10 @@ export default {
 
 The `FeathersVuexFind` component retrieves data from the API server, puts it in the Vuex store, then transparently retrieves the live, reactive data from the store and displays it to the user.
 
+### Example
+
 ```vue
-<FeathersVuexFind v-slot="{ items: users }" service="users" :query="{}" watch="query">
+<FeathersVuexFind v-slot="{ items: users }" service="users" :params="{ query: {} }" watch="query">
   <section>
     {{users}}
   </section>
@@ -76,12 +79,31 @@ The `FeathersVuexFind` component retrieves data from the API server, puts it in 
 
 ### Props
 
-- `service`: The path of the service
-- `query`: Only the query object from the `find` params.
+- `service {String}` - **required** the service path. This must match a service that has already been registered with FeathersVuex.
+- `query {Object}` <Badge text="deprecated" type="warning"/> **use `params` instead** - the query object. If only the `query` attribute is provided, the same query will be used for both the `find` getter and the `find` action. See the `fetchQuery` attribute for more information. When using server-side pagination, use the `fetchQuery` prop and the `query` prop for querying data from the local store. If the query is `null` or `undefined`, the query against both the API and store will be skipped. The find getter will return an empty array.
+- `watch {String|Array}` - specify the attributes of the `params` or `fetchParams` to watch. Pass 'params' to watch the entire params object. Pass 'params.query.name' to watch the 'name' property of the query. Watch is turned off by default, so the API server will only be queried once, by default. **Default: []**
+- `fetchQuery {Object}` <Badge text="deprecated" type="warning"/> **use `fetchParams` instead** - when provided, the `fetchQuery` serves as the query for the API server. The `query` param will be used against the service's local Vuex store. **Default: undefined**
+- `params {Object}` - the params object. If only the `params` attribute is provided, te same params will be used for both the `find` getter and the `find` action. See the `fetchParams` attribute for more information. <Badge text="3.11.0+" />
+- `fetchParams {Object}` - when provided, the `fetchParams` servers as the params for the API server. The `params` will be used against the service's local Vuex store. <Badge text="3.11.0+" />
+- `queryWhen {Boolean|Function}` - the query to the server will only be made when this evaluates to true.  **Default: true**
+- `local {Boolean}` - when set to true, will only use the `query` prop to get data from the local Vuex store. It will disable queries to the API server. **Default:false**
+- `editScope {Function}` - a utility function that allows you to modify the scope data, and even add attributes to it, before providing it to the default slot. You can also use it to pull data into the current component's data (though that may be less recommended, it can come in handy).  See the "Scope Data" section to learn more about what props are available in the scope object. **Default: scope => scope**
+- `temps {Boolean}` <Badge text="deprecated" type="warning"/> **use `params: { query: {}, temps: true }` instead** - Enable `temps` to include temporary records (from `state.tempsById`) in the find getter results. **Default: false**
+- `qid {String}` - The query identifier used for storing pagination data in the Vuex store. See the service module docs to see what you'll find inside. The default value is a random 10-character string. This means that by default, in theory, no two components will share the same pagination data, nor will they overwrite each other's pagination data. You can, of course, force them to use the same pagination data by giving them both the same `qid`, if there's a use case for that. **Default: randomString(10)**
+
+### Scope Data
+
+- `items {Array}` - The resulting array of records for find operations.
+- `isFindPending {Boolean}` - When there's an active request to the API server, this will be `true`.  This is not the same as the `isFindPending` from the Vuex state.  The value in the Vuex state is `true` whenever **any** component is querying data from that same service.  This `isFindPending` attribute is specific to each component instance.
+- `pagination {Object}` - pagination data from the Vuex store, keyed by the `qid` attribute.  By default, this will be specific to this component instance. (If you find a use case for sharing pagination between component instances, you can give both components the same `qid` string as a prop.)
+- `queryInfo {Object}` - the queryInfo for the `pagination` object. Includes the `total` prop for server side pagination
+- `pageInfo {Object}` - the pageInfo includes the queried ids and is necessary for server side pagination
 
 ## FeathersVuexGet
 
 The `FeathersVuexGet` component allows fetching data from directly inside a template.  It makes the slot scope available to the child components.  Note that in `feathers-vuex@3.3.0` the component now includes support for `params` and `fetchParams` props.  These are meant to replace the `query` and `fetchQuery` props.  The `params` allow you, for example, to configure a project to pass custom params to the server.  This would require use of custom hooks.
+
+### Example
 
 ```html
 <template>
@@ -109,9 +131,55 @@ export default {
 </script>
 ```
 
+### Props
+
+- `service {String}` - **required** the service path. This must match a service that has already been registered with FeathersVuex.
+- `id {Number|String}` - when performing a `get` request, serves as the id for the request. This is automatically watched, so if the `id` changes, an API request will be made and the data will be updated.  **Default: undefined**
+- `query {Object}` <Badge text="deprecated" type="warning"/> **use `params` instead** - the query object. If only the `query` attribute is provided, the same query will be used for both the `get` getter and the `get` action. See the `fetchQuery` attribute for more information. When using server-side pagination, use the `fetchQuery` prop and the `query` prop for querying data from the local store. If the query is `null` or `undefined`, the query against both the API and store will be skipped. The find getter will return an empty array.
+- `watch {String|Array}` - specify the attributes of the `params` or `fetchParams` to watch. Pass 'params' to watch the entire params object. Pass 'params.query.name' to watch the 'name' property of the query. Watch is turned off by default, so the API server will only be queried once, by default.  The only exception is for the `id` prop.  The `id` prop in the `FeathersVuexGet` component is always watched.  **Default: []**
+- `fetchQuery {Object}` <Badge text="deprecated" type="warning"/> **use `fetchParams` instead** - when provided, the `fetchQuery` serves as the query for the API server. The `query` param will be used against the service's local Vuex store. **Default: undefined**
+- `params {Object}` - the params object. If only the `params` attribute is provided, te same params will be used for both the `get` getter and the `get` action. See the `fetchParams` attribute for more information.
+- `fetchParams {Object}` - when provided, the `fetchParams` servers as the params for the API server. The `params` will be used against the service's local Vuex store.
+- `queryWhen {Boolean|Function}` - the query to the server will only be made when this evaluates to true.  **Default: true**
+- `local {Boolean}`: when set to true, will only use the `params` prop to get data from the local Vuex store. It will disable queries to the API server. **Default:false**
+- `editScope {Function}` - a utility function that allows you to modify the scope data, and even add attributes to it, before providing it to the default slot. You can also use it to pull data into the current component's data (though that may be less recommended, it can come in handy).  See the "Scope Data" section to learn more about what props are available in the scope object. **Default: scope => scope**
+
+### Scope Data
+
+- `item {Object}` - The resulting record for the get operation.
+- `isGetPending {Boolean}` - When there's an active request to the API server, this will be `true`.  This is not the same as the `isGetPending` from the Vuex state.  The value in the Vuex state is `true` whenever **any** component is querying data from that same service.  This `isGetPending` attribute is specific to each component instance.
+
+## FeathersVuexCount <Badge text="3.11.0+" />
+
+The `FeathersVuexCount` component allows displaying a count of records. It makes the slot scope available to the child components. It adds `$limit: 0` to the passed params in the background. This will only run a (fast) counting query against the database.
+
+> **Note:** it only works for services with enabled pagination!
+
+```vue
+<FeathersVuexCount v-slot="{ total }" service="users">
+  <section>
+    {{users}}
+  </section>
+</FeathersVuexCount>
+```
+
+### Props
+
+- `service {String}` - The path of the service
+- `params {Object}` - The params object passed to the `count` getter/action.
+- `fetchParams {Object}` - A seperate params object for the `count` action
+- `queryWhen {Boolean|Function(params)}` - the query to the server will only be made when this evaluates to true.  **Default: true**
+- `watch {String|Array}` - specify the attributes of the `params` or `fetchParams` to watch. Pass 'params' to watch the entire params object. Pass 'params.query.name' to watch the 'name' property of the query. Watch is turned off by default, so the API server will only be queried once, by default. **Default: []**
+- `local {Boolean}`: when set to true, will only use the `params` prop to get data from the local Vuex store. It will disable queries to the API server. **Default:false**
+
+### Scope Data
+
+- `total {Number}` - The number of found records.
+- `isCountPending {Boolean}` - When there's an active request to the API server, this will be `true`.
+
 ## A note about the internal architecture
 
-These components use Vuex getters (to query data from the local store) and actions (to query data from the API server).  When a `query` or `id` is provided, the components pull data from the API server and put it into the store.  That same `query` or `id` is then used to pull data from the local Vuex store.  Keep this in mind, especially when attempting to use server-side pagination.  To use server-side pagination, use the `query` prop for pulling data from the local vuex store, then use the `fetchQuery` prop to retrieve data from the API server.
+These components use Vuex getters (to query data from the local store) and actions (to query data from the API server).  When a `params` or `id` is provided, the components pull data from the API server and put it into the store. That same `params` or `id` is then used to pull data from the local Vuex store. Keep this in mind, especially when attempting to use server-side pagination. To use server-side pagination, use the `params` prop for pulling data from the local vuex store, then use the `fetchParams` prop to retrieve data from the API server.
 
 ## Registering the components
 
@@ -120,48 +188,27 @@ These components are automatically registered globally when using the Feathers-V
 If you prefer to manually register the component, pass `{ components: false }` as options when using the FeathersVuex Vue plugin, then do the following:
 
 ```js
-import { FeathersVuexFind, FeathersVuexGet } from 'feathers-vuex'
+import { FeathersVuexFind, FeathersVuexGet, FeathersVuexCount } from 'feathers-vuex'
 
 // in your component
 components: {
   FeathersVuexFind,
-  FeathersVuexGet
+  FeathersVuexGet,
+  FeathersVuexCount
 }
 
 // or globally registered
 Vue.component('FeathersVuexFind', FeathersVuexFind)
 Vue.component('FeathersVuexGet', FeathersVuexGet)
+Vue.component('FeathersVuexCount', FeathersVuexCount)
 ```
-
-## Props for both components
-
-The `<FeathersVuexFind>` and `FeathersVuexGet>` components share the following props in common. Unique props are found below.
-
-- **service {String}**: **required** the service path. This must match a service that has already been registered with FeathersVuex.
-- **query {Object}**: the query object. If only the `query` attribute is provided, the same query will be used for both the `find` getter and the `find` action. See the `fetchQuery` attribute for more information. When using server-side pagination, use the `fetchQuery` prop and the `query` prop for querying data from the local store. If the query is `null` or `undefined`, the query against both the API and store will be skipped. The find getter will return an empty array.
-- **watch {String|Array}**: specify the attributes of the `query` or `fetchQuery` to watch. Pass 'query' to watch the entire query object.  Pass 'query.name' to watch the 'name' property of the query. Watch is turned off by default, so the API server will only be queried once, by default.  The only exception is for the `id` prop.  The `id` prop in the `FeathersVuexGet` component is always watched.  **Default: []**
-- **fetchQuery {Object}**: when provided, the `fetchQuery` serves as the query for the API server. The `query` param will be used against the service's local Vuex store. **Default: undefined**
-- **queryWhen {Boolean|Function}**: the query to the server will only be made when this evaluates to true.  **Default: true**
-- **local {Boolean}**: when set to true, will only use the `query` prop to get data from the local Vuex store. It will disable queries to the API server. **Default:false**
-- **editScope {Function}**: a utility function that allows you to modify the scope data, and even add attributes to it, before providing it to the default slot. You can also use it to pull data into the current component's data (though that may be less recommended, it can come in handy).  See the "Scope Data" section to learn more about what props are available in the scope object. **Default: scope => scope**
-- **temps {Boolean}**: Enable `temps` to include temporary records (from `state.tempsById`) in the find getter results. **Default: false**
-
-## Props unique to `<FeathersVuexFind>`
-
-- **qid {String}** - The query identifier used for storing pagination data in the Vuex store. See the service module docs to see what you'll find inside.  The default value is a random 10-character string.  This means that by default, in theory, no two components will share the same pagination data, nor will they overwrite each other's pagination data.  You can, of course, force them to use the same pagination data by giving them both the same `qid`, if there's a use case for that.  **Default: randomString(10)**
-
-## Props for `<FeathersVuexGet>`
-
-The `<FeathersVuexGet>` component has these unique props.
-
-- **id {Number|String}** - when performing a `get` request, serves as the id for the request. This is automatically watched, so if the `id` changes, an API request will be made and the data will be updated.  **Default: undefined**
 
 ## Scope Data
 
-When using these components, the scope data will become available to the first element nested inside the `FeathersVuexFind` or `FeathersVuexGet` tags.  It's accessible using the `scope-data="props"` attribute:
+When using these components, the scope data will become available to the `FeathersVuexFind` or `FeathersVuexGet` tags. It's accessible using the `v-slot="props"` attribute:
 
 ```html
-<FeathersVuexFind v-slot="props" service="categories" :query="{}">
+<FeathersVuexFind v-slot="props" service="categories" :params="{ query: {} }">
   <div>
     {{props.items}}
   </div>
@@ -170,25 +217,14 @@ When using these components, the scope data will become available to the first e
 
 By default, the following props are available in the scope data:
 
-### FeathersVuexFind
-
-- **items {Array}** The resulting array of records for find operations.
-- **isFindPending {Boolean}** When there's an active request to the API server, this will be `true`.  This is not the same as the `isFindPending` from the Vuex state.  The value in the Vuex state is `true` whenever **any** component is querying data from that same service.  This `isFindPending` attribute is specific to each component instance.
-- **pagination {Object}** pagination data from the Vuex store, keyed by the `qid` attribute.  By default, this will be specific to this component instance. (If you find a use case for sharing pagination between component instances, you can give both components the same `qid` string as a prop.)
-
-### FeathersVuexGet
-
-- **item {Object}**  The resulting object for `get` operations
-- **isGetPending {Boolean}** The same as the `isFindPending`, but for `get` requests.
-
-It's also possible to modify the scope data by passing a function as the `edit-scope` prop.  See the example for [modifying scope data](#Modify-the-scope-data)
+It's also possible to modify the scope data by passing a function as the `edit-scope` prop. See the example for [modifying scope data](#Modify-the-scope-data)
 
 ### Destructuring props
 
-Use the object destructuring syntax to pull specific variables out of the `slot-scope` object.  In the following example, instead of using `v-slot="props"`, it directly accesses the `items` prop through destructuring:
+Use the object destructuring syntax to pull specific variables out of the `v-slot` object.  In the following example, instead of using `v-slot="props"`, it directly accesses the `items` prop through destructuring:
 
 ```html
-<FeathersVuexFind v-slot="{ items }" service="categories" :query="{}">
+<FeathersVuexFind v-slot="{ items }" service="categories" :params="{ query: {} }">
   <div>
     {{items}}
   </div>
@@ -197,10 +233,10 @@ Use the object destructuring syntax to pull specific variables out of the `slot-
 
 ### Renaming props with destructuring
 
-You can also rename scope props through the Object destructuring syntax.  The  `slot-scope` in the next example shows how to give the items a more-descriptive name:
+You can also rename scope props through the Object destructuring syntax.  The  `v-slot` in the next example shows how to give the items a more-descriptive name:
 
 ```html
-<FeathersVuexFind v-slot="{ items: categories } service="categories" :query="{}">
+<FeathersVuexFind v-slot="{ items: categories } service="categories" :params="{ query: {} }"">
   <div>
     {{categories}}
   </div>
@@ -226,7 +262,7 @@ In this example, only the `service` attribute is provided. There is no `query` n
 This example fetches data from the API server because a query was provided.  Internally, this same `query` is used for both the `find` action and the `find` getter.  Read other examples to see how to use distinct queries.  Be aware that if you use pagination directives like `$skip` or `$limit`, you must use two queries to get the records you desire.
 
 ```html
-<FeathersVuexFind v-slot="props" service="todos" :query="{}">
+<FeathersVuexFind v-slot="props" service="todos" :params="{ query: {} }">
   <div>
     {{props.items}}
   </div>
@@ -238,7 +274,7 @@ This example fetches data from the API server because a query was provided.  Int
 If you've already pulled a bunch of data from the server, you can use the `local` prop to only query the local data:
 
 ```html
-<FeathersVuexFind v-slot="props" service="todos" :query="{}" local>
+<FeathersVuexFind v-slot="props" service="todos" :params="{ query: {} }" local>
   <div>
     {{props.items}}
   </div>
@@ -253,8 +289,8 @@ Sometimes you want to query new data from the server whenever the query changes.
 <FeathersVuexFind
   v-slot="props"
   service="todos"
-  :query="{ isComplete: true }"
-  watch="query"
+  :params="{ query: { isComplete: true } }"
+  watch="params"
 >
   <div>
     {{props.items}}
@@ -268,8 +304,8 @@ This next example watches a single prop from the query:
 <FeathersVuexFind
   v-slot="props"
   service="todos"
-  :query="{ isComplete: true, dueDate: 'today' }"
-  watch="query.dueDate"
+  :params="{ query: { isComplete: true, dueDate: 'today' } }"
+  watch="params.query.dueDate"
 >
   <div>
     {{props.items}}
@@ -283,8 +319,8 @@ You can also provide an array of strings to watch multiple properties:
 <FeathersVuexFind
   v-slot="props"
   service="dogs"
-  :query="{ breed: 'mixed', bites: true, hasWorms: false }"
-  :watch="['query.breed', 'query.bites']"
+  :params="{ query: { breed: 'mixed', bites: true, hasWorms: false }}"
+  :watch="['params.query.breed', 'params.query.bites']"
 >
   <div>
     {{props.items}}
@@ -292,18 +328,18 @@ You can also provide an array of strings to watch multiple properties:
 </FeathersVuexFind>
 ```
 
-### Use a distinct `query` and `fetchQuery`
+### Use a distinct `params` and `fetchParams`
 
-In this scenario, the `fetchQuery` is be used to grab a larger dataset from the API server (all todos with a matching `userId`). The `query` is used by the `find` getter to display a subset of this data from the store.  If the `isComplete` attribute gets set to `true`, only completed todos will be displayed.  Since a `fetchQuery` is provided, the `watch` strings will be modified internally to watch the `fetchQuery` object.  This means if you are watching `query.userId` and you add a `fetchQuery`, the component is smart enough to know you meant `fetchQuery.userId`. You don't have to rewrite your `watch` attribute after adding a `fetchQuery` prop.
+In this scenario, the `fetchParams` is be used to grab a larger dataset from the API server (all todos with a matching `userId`). The `params` is used by the `find` getter to display a subset of this data from the store.  If the `isComplete` attribute gets set to `true`, only completed todos will be displayed.  Since a `fetchParams` is provided, the `watch` strings will be modified internally to watch the `fetchParams` object.  This means if you are watching `params.query.userId` and you add a `fetchParams`, the component is smart enough to know you meant `fetchParams.query.userId`. You don't have to rewrite your `watch` attribute after adding a `fetchParams` prop.
 
 ```html
 <template>
   <FeathersVuexFind
     v-slot="{ items: todos }"
     service="todos"
-    :query="{ isComplete }"
-    :fetchQuery="{ userId }"
-    watch="query.userId"
+    :params="{ query: { isComplete } }"
+    :fetch-params="{ query: { userId } }"
+    watch="params.query.userId"
   >
     <div>
       {{todos}}
@@ -330,7 +366,7 @@ The `edit-scope` function allows you to modify the scope before passing it down 
   <FeathersVuexFind
     v-slot="{ parentCategories, categoriesByParent }"
     service="categories"
-    :query="{}"
+    :params="{ query: {} }"
     :edit-scope="prepareCategories"
   >
     <ul>
@@ -365,15 +401,15 @@ export default {
 
 ### server-side pagination
 
-When you want to use server-side pagination you need to pass the ids from the server to vuex. It can be done by a combination of `query`, `fetchQuery` and `editScope` as described below. The `fetchQuery`-prop is only computed after items from the server arrived. The ids for the `find` getter as well as the total amount of available values `total` are extracted by the `edit-scope` function and stored in `data`:
+When you want to use server-side pagination you need to pass the ids from the server to vuex. It can be done by a combination of `params`, `fetchParams` and `editScope` as described below. The `fetchParams`-prop is only computed after items from the server arrived. The ids for the `find` getter as well as the total amount of available values `total` are extracted by the `edit-scope` function and stored in `data`:
 
 ```html
 <template>
   <FeathersVuexFind
     v-slot="{ items: todos }"
     :service="service"
-    :query="internalQuery"
-    :fetch-query="fetchQuery"
+    :params="internalParams"
+    :fetch-params="fetchParams"
     :edit-scope="getPaginationInfo"
   >
     <div>
@@ -388,8 +424,10 @@ export default {
     return {
       service: 'users',
       ids: [],
-      query: {
-        isComplete: true
+      params: {
+        query: {
+          isComplete: true
+        },
       },
       total: 0,
       limit: 10,
@@ -397,16 +435,20 @@ export default {
     };
   },
   computed: {
-    internalQuery() {
+    internalParams() {
       const { idField } = this.$store.state[this.service];
       return {
-        [idField]: {
-          $in: this.ids
+        query: {
+          [idField]: {
+            $in: this.ids
+          }
         }
       };
     },
-    fetchQuery() {
-      return Object.assign({}, this.query, { $limit: this.limit, $skip: this.skip });
+    fetchParams() {
+      const query = Object.assign({}, this.params.query, { $limit: this.limit, $skip: this.skip });
+
+      return Object.assign({}, this.params, { query });
     }
   },
   methods: {
@@ -435,8 +477,8 @@ Sometimes you only want to query the API server when certain conditions are met.
     <FeathersVuexFind
       v-slot="{ items: users, isFindPending: areUsersLoading }"
       service="users"
-      :query="usersQuery"
-      watch="query"
+      :params="usersParams"
+      watch="params"
       :queryWhen="userSearch.length > 2"
     >
       <ul :class="[ areUsersLoading && 'is-loading' ]">
@@ -454,10 +496,12 @@ export default {
     userSearch: ''
   }),
   computed: {
-    usersQuery () {
+    usersParams () {
       return {
-        email: { $regex: this.userSearch, $options: 'igm' },
-        $sort: { email: 1 }
+        query: {
+          email: { $regex: this.userSearch, $options: 'igm' },
+          $sort: { email: 1 }
+        }
       }
     }
   }

--- a/docs/model-classes.md
+++ b/docs/model-classes.md
@@ -5,17 +5,15 @@ sidebarDepth: 3
 
 # Data Modeling with Model Classes
 
-Feathers-Vuex 1.0 introduced some lightweight data modeling. Every service had its own, internal `FeathersVuexModel`. In version 2.0 this `FeathersVuexModel` is now called the `BaseModel` and is extendable, so you can add your own functionality.
+Feathers-Vuex 1.0 introduced some lightweight data modeling.  Every service had its own, internal `FeathersVuexModel`.  In version 2.0 this `FeathersVuexModel` is now called the `BaseModel` and is extendable, so you can add your own functionality.
+
 
 ## Extending the BaseModel Class
 
-While [setting up Feathers-Vuex](/getting-started.html#feathers-client-feathers-vuex), we exported the `BaseModel` class so that we could extend it. The below example shows how to import and extend the `BaseModel`. Each service must now have its own unique Model class.
+While [setting up Feathers-Vuex](/getting-started.html#feathers-client-feathers-vuex), we exported the `BaseModel` class so that we could extend it.  The below example shows how to import and extend the `BaseModel`.  Each service must now have its own unique Model class.
 
 ```js
-import feathersClient, {
-  makeServicePlugin,
-  BaseModel
-} from '../feathers-client'
+import feathersClient, { makeServicePlugin, BaseModel } from '../feathers-client'
 
 class User extends BaseModel {
   // Required for $FeathersVuex plugin to work after production transpile.
@@ -37,7 +35,7 @@ const servicePlugin = makeServicePlugin({
 })
 ```
 
-In case you're wondering, the `modelName` property is used to get around transpilation errors when using Babel with ES3 or ES5. Babel is still installed by default in most projects and generators. The `modelName` is used instead of the `name` property to provide a reliable name AFTER transpilation.
+In case you're wondering, the `modelName` property is used to get around transpilation errors when using Babel with ES3 or ES5.  Babel is still installed by default in most projects and generators.  The `modelName` is used instead of the `name` property to provide a reliable name AFTER transpilation.
 
 If you're working in an environment that doesn't support static properties on classes, you can always specify the static properties using the dot operator:
 
@@ -45,7 +43,7 @@ If you're working in an environment that doesn't support static properties on cl
 class User extends BaseModel {}
 
 User.modelName = 'User'
-User.instanceDefaults = function () {
+User.instanceDefaults = function() {
   return {
     email: '',
     password: ''
@@ -77,7 +75,7 @@ created () {
 
 ### findInStore(params)
 
-Model classes have a `findInStore` method, which is a proxy to the [`find` getter](./service-plugin.html#Service-Getters). <Badge text="1.7.0+" />
+Model classes have a `findInStore` method, which is a proxy to the [`find` getter](./service-plugin.html#Service-Getters).  <Badge text="1.7.0+" />
 
 ```js
 // In your Vue component
@@ -89,13 +87,13 @@ created () {
 
 ### count()
 
-Model classes have a `count` method, which is a proxy to the [`find` action] with the param `$limit: 0` automatically appended (./service-plugin.html#find-params). <Badge text="3.10.5+" />
+Model classes have a `count` method, which is a proxy to the [`find` action] with the param `$limit: 0` (./service-plugin.html#find-params). <Badge text="3.10.5+" />
 
 ```js
 // In your Vue component
 async created () {
   const { Todo } = this.$FeathersVuex.api
-  const todosCount = await Todo.count({ query: { priority: 'major'}})
+  const todosCount = await Todo.count()
   // or
   Todo.count().then((total) => { this.todoCount = total })
 }
@@ -103,19 +101,19 @@ async created () {
 
 ### countInStore(params)
 
-Model classes have a `countInStore` method, which is a proxy to the [`count` getter](./service-plugin.html#Service-Getters). <Badge text="3.10.5+" />
+Model classes have a `countInStore` method, which is a proxy to the [`count` getter](./service-plugin.html#Service-Getters).  <Badge text="3.10.5+" />
 
 ```js
 // In your Vue component
 created () {
   const { Todo } = this.$FeathersVuex.api
-  const todosCount = Todo.countInStore({ query: { priority: 'major'}})
+  const todosCount = Todo.countInStore()
 }
 ```
 
 ### get(id, params)
 
-Model classes have a `get` method, which is a proxy to the [`get` action](./service-plugin.html#get-id-or-get-id-params). <Badge text="1.7.0+" /> Notice that the signature is more Feathers-like, and doesn't require using an array to passing both id and params.
+Model classes have a `get` method, which is a proxy to the [`get` action](./service-plugin.html#get-id-or-get-id-params).   <Badge text="1.7.0+" /> Notice that the signature is more Feathers-like, and doesn't require using an array to passing both id and params.
 
 ```js
 // In your Vue component
@@ -127,7 +125,7 @@ created () {
 
 ### getFromStore(id, params)
 
-Model classes have a `getFromStore` method, which is a proxy to the [`get` getter](./service-plugin.html#Service-Getters). <Badge text="1.7.0+" /> Notice that the signature is more Feathers-like, and doesn't require using an array to passing both id and params.
+Model classes have a `getFromStore` method, which is a proxy to the [`get` getter](./service-plugin.html#Service-Getters).   <Badge text="1.7.0+" /> Notice that the signature is more Feathers-like, and doesn't require using an array to passing both id and params.
 
 ```js
 // In your Vue component
@@ -137,13 +135,13 @@ created () {
 }
 ```
 
-### instanceDefaults <Badge text="1.7.0+" />
+### instanceDefaults  <Badge text="1.7.0+" />
 
 `instanceDefaults(data, { store, models })`
 
-The `instanceDefaults` API was created in version 1.7 to prevent requiring to specify data for new instances created throughout the app. Depending on the complexity of the service's "business logic", it can save a lot of boilerplate. Notice that it is similar to the `setupInstance` method added in 2.0. The instanceDefaults method should ONLY be used to return default values for a new instance. Use `setupInstance` to handle other transformations on the data.
+The `instanceDefaults` API was created in version 1.7 to prevent requiring to specify data for new instances created throughout the app.  Depending on the complexity of the service's "business logic", it can save a lot of boilerplate.  Notice that it is similar to the `setupInstance` method added in 2.0.  The instanceDefaults method should ONLY be used to return default values for a new instance.  Use `setupInstance` to handle other transformations on the data.
 
-Starting with version 2.0, `instanceDefaults` must be provided as a function. The function will be called with the following arguments and should return an object of default properties for new instances.
+Starting with version 2.0, `instanceDefaults` must be provided as a function.  The function will be called with the following arguments and should return an object of default properties for new instances.
 
 - `data {Object}` - The instance data
 - An `utils` object containing these props:
@@ -164,15 +162,15 @@ instanceDefaults(data, { store, models }) {
 }
 ```
 
-With the above attributes in place, you no longer have to manually specify any of the listed attributes. You can, however, provided data to replace them. Calling `new User({ firstName: 'Marshall' })` will create the instance with the `firstName` filled in, already.
+With the above attributes in place, you no longer have to manually specify any of the listed attributes.  You can, however, provided data to replace them.  Calling `new User({ firstName: 'Marshall' })` will create the instance with the `firstName` filled in, already.
 
-One important note, the `isAdmin` attribute is specified in the above example in order to allow immediate binding in a form. You would pretty much NEVER allow specifying `isAdmin` from the client and storing it on the server. Attributes related to roles and app security should pretty much ALWAYS be written in hooks on the API server.
+One important note, the `isAdmin` attribute is specified in the above example in order to allow immediate binding in a form.  You would pretty much NEVER allow specifying `isAdmin` from the client and storing it on the server.  Attributes related to roles and app security should pretty much ALWAYS be written in hooks on the API server.
 
-### setupInstance <Badge text="2.0.0+" />
+### setupInstance  <Badge text="2.0.0+" />
 
 `setupInstance(data, { store, models })`
 
-A new `setupinstance` class method is now available in version 2.0. This method allows you to transform the data and setup the final instance based on incoming data. For example, you can access the `models` object to reference other service Model classes and create data associations.
+A new `setupinstance` class method is now available in version 2.0.  This method allows you to transform the data and setup the final instance based on incoming data.  For example, you can access the `models` object to reference other service Model classes and create data associations.
 
 The function will be called during model instance construction with the following arguments and should return an object containing properties that'll be merged into the new instance.
 
@@ -181,9 +179,10 @@ The function will be called during model instance construction with the followin
   - `store` - The vuex store
   - `models {Object}` The `globalModels` object, which is the same as you'll find inside a component at `this.$FeathersVuex`.
 
-For an example of how you might use `setupInstance`, suppose we have two services: Users and Posts. Assume that the API request to get a user includes their `posts`, already populated on the data. The `instanceDefaults` allows us to convert the array of `posts` into an array of `Post` instances.
+For an example of how you might use `setupInstance`, suppose we have two services: Users and Posts.  Assume that the API request to get a user includes their `posts`, already populated on the data.  The `instanceDefaults` allows us to convert the array of `posts` into an array of `Post` instances.
 
 > If you're looking for a great solution for populating data to work with Feathers-Vuex, check out [feathers-graph-populate](https://feathers-graph-populate.netlify.app/).
+
 
 ```js
 // The setupInstance method on an imaginary User model.
@@ -212,7 +211,7 @@ Remove an event handler.
 
 ## Model Events <Badge text="2.3.0+" />
 
-Model classes are EventEmitter instances which emit service events when received (technically, EventEmitter methods are mixed onto each Model class). All FeathersJS events are supported. Oh, and one more thing: it works with `feathers-rest` (you won't receive socket events, but you can listen for when instances are created in other parts of the app.)
+Model classes are EventEmitter instances which emit service events when received (technically, EventEmitter methods are mixed onto each Model class).  All FeathersJS events are supported.  Oh, and one more thing: it works with `feathers-rest` (you won't receive socket events, but you can listen for when instances are created in other parts of the app.)
 
 Here’s an example of how to use it in a component:
 
@@ -232,12 +231,12 @@ export default {
 }
 ```
 
-Since they have all of the EventEmitter methods, Model classes can be used as a data-layer Event Bus. You can even use custom event names:
+Since they have all of the EventEmitter methods, Model classes can be used as a data-layer Event Bus.  You can even use custom event names:
 
 ```js
 const { Todo } = this.$FeathersVuex.api
 
-Todo.on('custom-event', (data) => {
+Todo.on('custom-event', data => {
   console.log(data) // { test: true }
 })
 
@@ -265,7 +264,7 @@ const { Todo } = Vue.$FeathersVuex.api
 const todo = new Todo({ description: 'Do something!' })
 ```
 
-The examples above show instantiating a new Model instance without an `id` field. In this case, the record is not added to the Vuex store. If you instantiate a record **with an `id`** field, it **will** get added to the Vuex store. _Note: This field is customizable using the `idField` option for this service._
+The examples above show instantiating a new Model instance without an `id` field. In this case, the record is not added to the Vuex store.  If you instantiate a record **with an `id`** field, it **will** get added to the Vuex store. *Note: This field is customizable using the `idField` option for this service.*
 
 Now that we have Model instances, let's take a look at the functionality they provide. Each instance will include the following methods:
 
@@ -277,25 +276,26 @@ Now that we have Model instances, let's take a look at the functionality they pr
 - `.commit()`
 - `.reset()`
 
-_Remember, if a record already has an attribute with any of these method names, it will be overwritten with the method._
+*Remember, if a record already has an attribute with any of these method names, it will be overwritten with the method.*
 
-These methods give access to many of the store `actions` and `mutations`. Using Model instances, you no longer have to use `mapActions` for `create`, `patch`, `update`, or `remove`. You also no longer have to use `mapMutations` for `createCopy`, `commitCopy`, or `resetCopy`.
+These methods give access to many of the store `actions` and `mutations`.  Using Model instances, you no longer have to use `mapActions` for `create`, `patch`, `update`, or `remove`.  You also no longer have to use `mapMutations` for `createCopy`, `commitCopy`, or `resetCopy`.
 
 ```js
-store.dispatch('todos/find', { query: {} }).then((response) => {
-  const { data } = response
-  const todo = data[0]
+store.dispatch('todos/find', { query: {} })
+  .then(response => {
+    const { data } = response
+    const todo = data[0]
 
-  todo.description = 'Read Nuxt.js docs'
-  todo.save() // Calls store.dispatch('todos/patch', [item.id, item, {}])
-})
+    todo.description = 'Read Nuxt.js docs'
+    todo.save() // Calls store.dispatch('todos/patch', [item.id, item, {}])
+  })
 ```
 
 ## Instance Methods
 
 ### `instance.save(params)`
 
-The `save` method is a convenience wrapper for the `create/patch` methods, by default. If the records has no `_id`, the `instance.create()` method will be used. The `params` argument will be used in the Feathers client request. See the [Feathers Service](https://docs.feathersjs.com/guides/basics/services.html#service-methods) docs, for reference on where params are used in each method.
+The `save` method is a convenience wrapper for the `create/patch` methods, by default. If the records has no `_id`, the `instance.create()` method will be used. The `params` argument will be used in the Feathers client request.  See the [Feathers Service](https://docs.feathersjs.com/guides/basics/services.html#service-methods) docs, for reference on where params are used in each method.
 
 ```js
 // In your Vue component
@@ -307,13 +307,13 @@ created () {
 }
 ```
 
-Once the `create` response returns, the record will have an `_id`. If you call `instance.save()` again, it will call `instance.patch()`. Which method is used depends soletly on the data having an id (that matches the `options.idfield` for this service).
+Once the `create` response returns, the record will have an `_id`.  If you call `instance.save()` again, it will call `instance.patch()`.  Which method is used depends soletly on the data having an id (that matches the `options.idfield` for this service).
 
 As mentioned, `save` performs either `create` or `patch`, but you can use the `preferUpdate` option to change the behavior to `create/update`.
 
 ### `instance.create(params)`
 
-The `create` method calls the `create` action (service method) using the instance data. The `params` argument will be used in the Feathers client request. See the [Feathers Service](https://docs.feathersjs.com/guides/basics/services.html#service-methods) docs, for reference.
+The `create` method calls the `create` action (service method) using the instance data. The `params` argument will be used in the Feathers client request.  See the [Feathers Service](https://docs.feathersjs.com/guides/basics/services.html#service-methods) docs, for reference.
 
 You might not ever need to use `.create()`, but can instead use the `.save()` method. Let `feathers-vuex` call `create` or `patch`.
 
@@ -327,9 +327,10 @@ todo.create() // --> Creates the todo on the server using the instance data
 
 ### `instance.patch(params)`
 
-The `patch` method calls the `patch` action (service method) using the instance data. The instance's id field is used for the `patch` id. The `params` argument will be used in the Feathers client request. See the [Feathers Service](https://docs.feathersjs.com/guides/basics/services.html#service-methods) docs, for reference.
+The `patch` method calls the `patch` action (service method) using the instance data. The instance's id field is used for the `patch` id.  The `params` argument will be used in the Feathers client request.  See the [Feathers Service](https://docs.feathersjs.com/guides/basics/services.html#service-methods) docs, for reference.
 
 Similar to the `.create()` method, you might not ever need to use `.patch()` if you just use `.save()` and let `feathers-vuex` figure out how to handle it.
+
 
 ```js
 const { Todo } = this.$FeathersVuex.api
@@ -340,7 +341,7 @@ todo.description = 'Do something else'
 todo.patch() // --> Sends a `patch` request the with the id and description.
 ```
 
-<Badge text="3.9.0+" /> As of version 3.9.0, you can provide an object as `params.data`, and Feathers-Vuex will use `params.data` as the patch data. This allows patching with partial data:
+<Badge text="3.9.0+" /> As of version 3.9.0, you can provide an object as `params.data`, and Feathers-Vuex will use `params.data` as the patch data.  This allows patching with partial data:
 
 ```js
 import { models } from 'feathers-vuex'
@@ -353,9 +354,9 @@ todo.patch({ data: { isComplete: true } })
 
 ### `instance.update(params)`
 
-The `update` method calls the `update` action (service method) using the instance data. The instance's id field is used for the `update` id. The `params` argument will be used in the Feathers client request. See the [Feathers Service](https://docs.feathersjs.com/guides/basics/services.html#service-methods) docs, for reference.
+The `update` method calls the `update` action (service method) using the instance data. The instance's id field is used for the `update` id. The `params` argument will be used in the Feathers client request.  See the [Feathers Service](https://docs.feathersjs.com/guides/basics/services.html#service-methods) docs, for reference.
 
-Use `.update()` whenever you want to completely replace the data on the server with the instance data. You can also set the `preferUpdate` option to `true` to make `.save()` call `.update()` when an id field is present on the instance.
+Use `.update()` whenever you want to completely replace the data on the server with the instance data.  You can also set the `preferUpdate` option to `true` to make `.save()` call `.update()` when an id field is present on the instance.
 
 ```js
 const { Todo } = this.$FeathersVuex.api
@@ -368,15 +369,16 @@ todo.update() // --> Sends a `update` request the with all instance data.
 
 ### `instance.remove(params)`
 
-The `remove` method calls the `remove` action (service method) using the instance data. The instance's id field is used for the `remove` id. The `params` argument will be used in the Feathers client request. See the [Feathers Service](https://docs.feathersjs.com/guides/basics/services.html#service-methods) docs, for reference.
+The `remove` method calls the `remove` action (service method) using the instance data. The instance's id field is used for the `remove` id. The `params` argument will be used in the Feathers client request.  See the [Feathers Service](https://docs.feathersjs.com/guides/basics/services.html#service-methods) docs, for reference.
 
 ```js
 const { Todo } = this.$FeathersVuex.api
 const todo = new Todo({ id: 1, description: 'Do something!' })
 
-todo.save().then((todo) => {
-  todo.remove() // --> Deletes the record from the server
-})
+todo.save()
+  .then(todo => {
+    todo.remove() // --> Deletes the record from the server
+  })
 ```
 
 ### `instance.clone()`
@@ -395,9 +397,9 @@ console.log(todo.description) // --> 'Do something else!'
 console.log(todoCopy.description) // --> 'Do something else!'
 ```
 
-There's another use case for using `.clone()`. Vuex has a `strict` mode that's really useful in development. It throws errors if any changes occur in the Vuex store `state` outside of mutations. Clone really comes in handy here, because you can make changes to the clone without having to write custom Vuex mutations. When you're finished making changes, call `.commit()` to update the store. This gives you `strict` mode compliance with little effort!
+There's another use case for using `.clone()`.  Vuex has a `strict` mode that's really useful in development.  It throws errors if any changes occur in the Vuex store `state` outside of mutations.  Clone really comes in handy here, because you can make changes to the clone without having to write custom Vuex mutations. When you're finished making changes, call `.commit()` to update the store. This gives you `strict` mode compliance with little effort!
 
-> Note: You could previously use the `keepCopiesInStore`<Badge text="deprecated" type="warning"/> option to keep copies in `state.copiesById`. In 2.0, this feature is deprecated and will be removed from the next release.
+> Note: You could previously use the `keepCopiesInStore`<Badge text="deprecated" type="warning"/> option to keep copies in `state.copiesById`.  In 2.0, this feature is deprecated and will be removed from the next release.
 
 ### `instance.commit()`
 

--- a/docs/model-classes.md
+++ b/docs/model-classes.md
@@ -85,15 +85,15 @@ created () {
 }
 ```
 
-### count()
+### count(params)
 
-Model classes have a `count` method, which is a proxy to the [`find` action] with the param `$limit: 0` (./service-plugin.html#find-params). <Badge text="3.10.5+" />
+Model classes have a `count` method, which is a proxy to the [`find` action] with the param `$limit: 0` automaticalluy appended. On the Feathers server, `$limit: 0` results in a fast count query. (./service-plugin.html#find-params). <Badge text="3.10.5+" />
 
 ```js
 // In your Vue component
 async created () {
   const { Todo } = this.$FeathersVuex.api
-  const todosCount = await Todo.count()
+  const todosCount = await Todo.count({ query: { priority: 'critical' }})
   // or
   Todo.count().then((total) => { this.todoCount = total })
 }
@@ -107,7 +107,7 @@ Model classes have a `countInStore` method, which is a proxy to the [`count` get
 // In your Vue component
 created () {
   const { Todo } = this.$FeathersVuex.api
-  const todosCount = Todo.countInStore()
+  const todosCount = Todo.countInStore({ query: { priority: 'critical' }})
 }
 ```
 

--- a/docs/model-classes.md
+++ b/docs/model-classes.md
@@ -5,15 +5,17 @@ sidebarDepth: 3
 
 # Data Modeling with Model Classes
 
-Feathers-Vuex 1.0 introduced some lightweight data modeling.  Every service had its own, internal `FeathersVuexModel`.  In version 2.0 this `FeathersVuexModel` is now called the `BaseModel` and is extendable, so you can add your own functionality.
-
+Feathers-Vuex 1.0 introduced some lightweight data modeling. Every service had its own, internal `FeathersVuexModel`. In version 2.0 this `FeathersVuexModel` is now called the `BaseModel` and is extendable, so you can add your own functionality.
 
 ## Extending the BaseModel Class
 
-While [setting up Feathers-Vuex](/getting-started.html#feathers-client-feathers-vuex), we exported the `BaseModel` class so that we could extend it.  The below example shows how to import and extend the `BaseModel`.  Each service must now have its own unique Model class.
+While [setting up Feathers-Vuex](/getting-started.html#feathers-client-feathers-vuex), we exported the `BaseModel` class so that we could extend it. The below example shows how to import and extend the `BaseModel`. Each service must now have its own unique Model class.
 
 ```js
-import feathersClient, { makeServicePlugin, BaseModel } from '../feathers-client'
+import feathersClient, {
+  makeServicePlugin,
+  BaseModel
+} from '../feathers-client'
 
 class User extends BaseModel {
   // Required for $FeathersVuex plugin to work after production transpile.
@@ -35,7 +37,7 @@ const servicePlugin = makeServicePlugin({
 })
 ```
 
-In case you're wondering, the `modelName` property is used to get around transpilation errors when using Babel with ES3 or ES5.  Babel is still installed by default in most projects and generators.  The `modelName` is used instead of the `name` property to provide a reliable name AFTER transpilation.
+In case you're wondering, the `modelName` property is used to get around transpilation errors when using Babel with ES3 or ES5. Babel is still installed by default in most projects and generators. The `modelName` is used instead of the `name` property to provide a reliable name AFTER transpilation.
 
 If you're working in an environment that doesn't support static properties on classes, you can always specify the static properties using the dot operator:
 
@@ -43,7 +45,7 @@ If you're working in an environment that doesn't support static properties on cl
 class User extends BaseModel {}
 
 User.modelName = 'User'
-User.instanceDefaults = function() {
+User.instanceDefaults = function () {
   return {
     email: '',
     password: ''
@@ -75,7 +77,7 @@ created () {
 
 ### findInStore(params)
 
-Model classes have a `findInStore` method, which is a proxy to the [`find` getter](./service-plugin.html#Service-Getters).  <Badge text="1.7.0+" />
+Model classes have a `findInStore` method, which is a proxy to the [`find` getter](./service-plugin.html#Service-Getters). <Badge text="1.7.0+" />
 
 ```js
 // In your Vue component
@@ -87,13 +89,13 @@ created () {
 
 ### count()
 
-Model classes have a `count` method, which is a proxy to the [`find` action] with the param `$limit: 0` (./service-plugin.html#find-params). <Badge text="3.10.5+" />
+Model classes have a `count` method, which is a proxy to the [`find` action] with the param `$limit: 0` automatically appended (./service-plugin.html#find-params). <Badge text="3.10.5+" />
 
 ```js
 // In your Vue component
 async created () {
   const { Todo } = this.$FeathersVuex.api
-  const todosCount = await Todo.count()
+  const todosCount = await Todo.count({ query: { priority: 'major'}})
   // or
   Todo.count().then((total) => { this.todoCount = total })
 }
@@ -101,19 +103,19 @@ async created () {
 
 ### countInStore(params)
 
-Model classes have a `countInStore` method, which is a proxy to the [`count` getter](./service-plugin.html#Service-Getters).  <Badge text="3.10.5+" />
+Model classes have a `countInStore` method, which is a proxy to the [`count` getter](./service-plugin.html#Service-Getters). <Badge text="3.10.5+" />
 
 ```js
 // In your Vue component
 created () {
   const { Todo } = this.$FeathersVuex.api
-  const todosCount = Todo.countInStore()
+  const todosCount = Todo.countInStore({ query: { priority: 'major'}})
 }
 ```
 
 ### get(id, params)
 
-Model classes have a `get` method, which is a proxy to the [`get` action](./service-plugin.html#get-id-or-get-id-params).   <Badge text="1.7.0+" /> Notice that the signature is more Feathers-like, and doesn't require using an array to passing both id and params.
+Model classes have a `get` method, which is a proxy to the [`get` action](./service-plugin.html#get-id-or-get-id-params). <Badge text="1.7.0+" /> Notice that the signature is more Feathers-like, and doesn't require using an array to passing both id and params.
 
 ```js
 // In your Vue component
@@ -125,7 +127,7 @@ created () {
 
 ### getFromStore(id, params)
 
-Model classes have a `getFromStore` method, which is a proxy to the [`get` getter](./service-plugin.html#Service-Getters).   <Badge text="1.7.0+" /> Notice that the signature is more Feathers-like, and doesn't require using an array to passing both id and params.
+Model classes have a `getFromStore` method, which is a proxy to the [`get` getter](./service-plugin.html#Service-Getters). <Badge text="1.7.0+" /> Notice that the signature is more Feathers-like, and doesn't require using an array to passing both id and params.
 
 ```js
 // In your Vue component
@@ -135,13 +137,13 @@ created () {
 }
 ```
 
-### instanceDefaults  <Badge text="1.7.0+" />
+### instanceDefaults <Badge text="1.7.0+" />
 
 `instanceDefaults(data, { store, models })`
 
-The `instanceDefaults` API was created in version 1.7 to prevent requiring to specify data for new instances created throughout the app.  Depending on the complexity of the service's "business logic", it can save a lot of boilerplate.  Notice that it is similar to the `setupInstance` method added in 2.0.  The instanceDefaults method should ONLY be used to return default values for a new instance.  Use `setupInstance` to handle other transformations on the data.
+The `instanceDefaults` API was created in version 1.7 to prevent requiring to specify data for new instances created throughout the app. Depending on the complexity of the service's "business logic", it can save a lot of boilerplate. Notice that it is similar to the `setupInstance` method added in 2.0. The instanceDefaults method should ONLY be used to return default values for a new instance. Use `setupInstance` to handle other transformations on the data.
 
-Starting with version 2.0, `instanceDefaults` must be provided as a function.  The function will be called with the following arguments and should return an object of default properties for new instances.
+Starting with version 2.0, `instanceDefaults` must be provided as a function. The function will be called with the following arguments and should return an object of default properties for new instances.
 
 - `data {Object}` - The instance data
 - An `utils` object containing these props:
@@ -162,15 +164,15 @@ instanceDefaults(data, { store, models }) {
 }
 ```
 
-With the above attributes in place, you no longer have to manually specify any of the listed attributes.  You can, however, provided data to replace them.  Calling `new User({ firstName: 'Marshall' })` will create the instance with the `firstName` filled in, already.
+With the above attributes in place, you no longer have to manually specify any of the listed attributes. You can, however, provided data to replace them. Calling `new User({ firstName: 'Marshall' })` will create the instance with the `firstName` filled in, already.
 
-One important note, the `isAdmin` attribute is specified in the above example in order to allow immediate binding in a form.  You would pretty much NEVER allow specifying `isAdmin` from the client and storing it on the server.  Attributes related to roles and app security should pretty much ALWAYS be written in hooks on the API server.
+One important note, the `isAdmin` attribute is specified in the above example in order to allow immediate binding in a form. You would pretty much NEVER allow specifying `isAdmin` from the client and storing it on the server. Attributes related to roles and app security should pretty much ALWAYS be written in hooks on the API server.
 
-### setupInstance  <Badge text="2.0.0+" />
+### setupInstance <Badge text="2.0.0+" />
 
 `setupInstance(data, { store, models })`
 
-A new `setupinstance` class method is now available in version 2.0.  This method allows you to transform the data and setup the final instance based on incoming data.  For example, you can access the `models` object to reference other service Model classes and create data associations.
+A new `setupinstance` class method is now available in version 2.0. This method allows you to transform the data and setup the final instance based on incoming data. For example, you can access the `models` object to reference other service Model classes and create data associations.
 
 The function will be called during model instance construction with the following arguments and should return an object containing properties that'll be merged into the new instance.
 
@@ -179,10 +181,9 @@ The function will be called during model instance construction with the followin
   - `store` - The vuex store
   - `models {Object}` The `globalModels` object, which is the same as you'll find inside a component at `this.$FeathersVuex`.
 
-For an example of how you might use `setupInstance`, suppose we have two services: Users and Posts.  Assume that the API request to get a user includes their `posts`, already populated on the data.  The `instanceDefaults` allows us to convert the array of `posts` into an array of `Post` instances.
+For an example of how you might use `setupInstance`, suppose we have two services: Users and Posts. Assume that the API request to get a user includes their `posts`, already populated on the data. The `instanceDefaults` allows us to convert the array of `posts` into an array of `Post` instances.
 
 > If you're looking for a great solution for populating data to work with Feathers-Vuex, check out [feathers-graph-populate](https://feathers-graph-populate.netlify.app/).
-
 
 ```js
 // The setupInstance method on an imaginary User model.
@@ -211,7 +212,7 @@ Remove an event handler.
 
 ## Model Events <Badge text="2.3.0+" />
 
-Model classes are EventEmitter instances which emit service events when received (technically, EventEmitter methods are mixed onto each Model class).  All FeathersJS events are supported.  Oh, and one more thing: it works with `feathers-rest` (you won't receive socket events, but you can listen for when instances are created in other parts of the app.)
+Model classes are EventEmitter instances which emit service events when received (technically, EventEmitter methods are mixed onto each Model class). All FeathersJS events are supported. Oh, and one more thing: it works with `feathers-rest` (you won't receive socket events, but you can listen for when instances are created in other parts of the app.)
 
 Here’s an example of how to use it in a component:
 
@@ -231,12 +232,12 @@ export default {
 }
 ```
 
-Since they have all of the EventEmitter methods, Model classes can be used as a data-layer Event Bus.  You can even use custom event names:
+Since they have all of the EventEmitter methods, Model classes can be used as a data-layer Event Bus. You can even use custom event names:
 
 ```js
 const { Todo } = this.$FeathersVuex.api
 
-Todo.on('custom-event', data => {
+Todo.on('custom-event', (data) => {
   console.log(data) // { test: true }
 })
 
@@ -264,7 +265,7 @@ const { Todo } = Vue.$FeathersVuex.api
 const todo = new Todo({ description: 'Do something!' })
 ```
 
-The examples above show instantiating a new Model instance without an `id` field. In this case, the record is not added to the Vuex store.  If you instantiate a record **with an `id`** field, it **will** get added to the Vuex store. *Note: This field is customizable using the `idField` option for this service.*
+The examples above show instantiating a new Model instance without an `id` field. In this case, the record is not added to the Vuex store. If you instantiate a record **with an `id`** field, it **will** get added to the Vuex store. _Note: This field is customizable using the `idField` option for this service._
 
 Now that we have Model instances, let's take a look at the functionality they provide. Each instance will include the following methods:
 
@@ -276,26 +277,25 @@ Now that we have Model instances, let's take a look at the functionality they pr
 - `.commit()`
 - `.reset()`
 
-*Remember, if a record already has an attribute with any of these method names, it will be overwritten with the method.*
+_Remember, if a record already has an attribute with any of these method names, it will be overwritten with the method._
 
-These methods give access to many of the store `actions` and `mutations`.  Using Model instances, you no longer have to use `mapActions` for `create`, `patch`, `update`, or `remove`.  You also no longer have to use `mapMutations` for `createCopy`, `commitCopy`, or `resetCopy`.
+These methods give access to many of the store `actions` and `mutations`. Using Model instances, you no longer have to use `mapActions` for `create`, `patch`, `update`, or `remove`. You also no longer have to use `mapMutations` for `createCopy`, `commitCopy`, or `resetCopy`.
 
 ```js
-store.dispatch('todos/find', { query: {} })
-  .then(response => {
-    const { data } = response
-    const todo = data[0]
+store.dispatch('todos/find', { query: {} }).then((response) => {
+  const { data } = response
+  const todo = data[0]
 
-    todo.description = 'Read Nuxt.js docs'
-    todo.save() // Calls store.dispatch('todos/patch', [item.id, item, {}])
-  })
+  todo.description = 'Read Nuxt.js docs'
+  todo.save() // Calls store.dispatch('todos/patch', [item.id, item, {}])
+})
 ```
 
 ## Instance Methods
 
 ### `instance.save(params)`
 
-The `save` method is a convenience wrapper for the `create/patch` methods, by default. If the records has no `_id`, the `instance.create()` method will be used. The `params` argument will be used in the Feathers client request.  See the [Feathers Service](https://docs.feathersjs.com/guides/basics/services.html#service-methods) docs, for reference on where params are used in each method.
+The `save` method is a convenience wrapper for the `create/patch` methods, by default. If the records has no `_id`, the `instance.create()` method will be used. The `params` argument will be used in the Feathers client request. See the [Feathers Service](https://docs.feathersjs.com/guides/basics/services.html#service-methods) docs, for reference on where params are used in each method.
 
 ```js
 // In your Vue component
@@ -307,13 +307,13 @@ created () {
 }
 ```
 
-Once the `create` response returns, the record will have an `_id`.  If you call `instance.save()` again, it will call `instance.patch()`.  Which method is used depends soletly on the data having an id (that matches the `options.idfield` for this service).
+Once the `create` response returns, the record will have an `_id`. If you call `instance.save()` again, it will call `instance.patch()`. Which method is used depends soletly on the data having an id (that matches the `options.idfield` for this service).
 
 As mentioned, `save` performs either `create` or `patch`, but you can use the `preferUpdate` option to change the behavior to `create/update`.
 
 ### `instance.create(params)`
 
-The `create` method calls the `create` action (service method) using the instance data. The `params` argument will be used in the Feathers client request.  See the [Feathers Service](https://docs.feathersjs.com/guides/basics/services.html#service-methods) docs, for reference.
+The `create` method calls the `create` action (service method) using the instance data. The `params` argument will be used in the Feathers client request. See the [Feathers Service](https://docs.feathersjs.com/guides/basics/services.html#service-methods) docs, for reference.
 
 You might not ever need to use `.create()`, but can instead use the `.save()` method. Let `feathers-vuex` call `create` or `patch`.
 
@@ -327,10 +327,9 @@ todo.create() // --> Creates the todo on the server using the instance data
 
 ### `instance.patch(params)`
 
-The `patch` method calls the `patch` action (service method) using the instance data. The instance's id field is used for the `patch` id.  The `params` argument will be used in the Feathers client request.  See the [Feathers Service](https://docs.feathersjs.com/guides/basics/services.html#service-methods) docs, for reference.
+The `patch` method calls the `patch` action (service method) using the instance data. The instance's id field is used for the `patch` id. The `params` argument will be used in the Feathers client request. See the [Feathers Service](https://docs.feathersjs.com/guides/basics/services.html#service-methods) docs, for reference.
 
 Similar to the `.create()` method, you might not ever need to use `.patch()` if you just use `.save()` and let `feathers-vuex` figure out how to handle it.
-
 
 ```js
 const { Todo } = this.$FeathersVuex.api
@@ -341,7 +340,7 @@ todo.description = 'Do something else'
 todo.patch() // --> Sends a `patch` request the with the id and description.
 ```
 
-<Badge text="3.9.0+" /> As of version 3.9.0, you can provide an object as `params.data`, and Feathers-Vuex will use `params.data` as the patch data.  This allows patching with partial data:
+<Badge text="3.9.0+" /> As of version 3.9.0, you can provide an object as `params.data`, and Feathers-Vuex will use `params.data` as the patch data. This allows patching with partial data:
 
 ```js
 import { models } from 'feathers-vuex'
@@ -354,9 +353,9 @@ todo.patch({ data: { isComplete: true } })
 
 ### `instance.update(params)`
 
-The `update` method calls the `update` action (service method) using the instance data. The instance's id field is used for the `update` id. The `params` argument will be used in the Feathers client request.  See the [Feathers Service](https://docs.feathersjs.com/guides/basics/services.html#service-methods) docs, for reference.
+The `update` method calls the `update` action (service method) using the instance data. The instance's id field is used for the `update` id. The `params` argument will be used in the Feathers client request. See the [Feathers Service](https://docs.feathersjs.com/guides/basics/services.html#service-methods) docs, for reference.
 
-Use `.update()` whenever you want to completely replace the data on the server with the instance data.  You can also set the `preferUpdate` option to `true` to make `.save()` call `.update()` when an id field is present on the instance.
+Use `.update()` whenever you want to completely replace the data on the server with the instance data. You can also set the `preferUpdate` option to `true` to make `.save()` call `.update()` when an id field is present on the instance.
 
 ```js
 const { Todo } = this.$FeathersVuex.api
@@ -369,16 +368,15 @@ todo.update() // --> Sends a `update` request the with all instance data.
 
 ### `instance.remove(params)`
 
-The `remove` method calls the `remove` action (service method) using the instance data. The instance's id field is used for the `remove` id. The `params` argument will be used in the Feathers client request.  See the [Feathers Service](https://docs.feathersjs.com/guides/basics/services.html#service-methods) docs, for reference.
+The `remove` method calls the `remove` action (service method) using the instance data. The instance's id field is used for the `remove` id. The `params` argument will be used in the Feathers client request. See the [Feathers Service](https://docs.feathersjs.com/guides/basics/services.html#service-methods) docs, for reference.
 
 ```js
 const { Todo } = this.$FeathersVuex.api
 const todo = new Todo({ id: 1, description: 'Do something!' })
 
-todo.save()
-  .then(todo => {
-    todo.remove() // --> Deletes the record from the server
-  })
+todo.save().then((todo) => {
+  todo.remove() // --> Deletes the record from the server
+})
 ```
 
 ### `instance.clone()`
@@ -397,9 +395,9 @@ console.log(todo.description) // --> 'Do something else!'
 console.log(todoCopy.description) // --> 'Do something else!'
 ```
 
-There's another use case for using `.clone()`.  Vuex has a `strict` mode that's really useful in development.  It throws errors if any changes occur in the Vuex store `state` outside of mutations.  Clone really comes in handy here, because you can make changes to the clone without having to write custom Vuex mutations. When you're finished making changes, call `.commit()` to update the store. This gives you `strict` mode compliance with little effort!
+There's another use case for using `.clone()`. Vuex has a `strict` mode that's really useful in development. It throws errors if any changes occur in the Vuex store `state` outside of mutations. Clone really comes in handy here, because you can make changes to the clone without having to write custom Vuex mutations. When you're finished making changes, call `.commit()` to update the store. This gives you `strict` mode compliance with little effort!
 
-> Note: You could previously use the `keepCopiesInStore`<Badge text="deprecated" type="warning"/> option to keep copies in `state.copiesById`.  In 2.0, this feature is deprecated and will be removed from the next release.
+> Note: You could previously use the `keepCopiesInStore`<Badge text="deprecated" type="warning"/> option to keep copies in `state.copiesById`. In 2.0, this feature is deprecated and will be removed from the next release.
 
 ### `instance.commit()`
 

--- a/docs/model-classes.md
+++ b/docs/model-classes.md
@@ -85,6 +85,32 @@ created () {
 }
 ```
 
+### count()
+
+Model classes have a `count` method, which is a proxy to the [`find` action] with the param `$limit: 0` (./service-plugin.html#find-params). <Badge text="3.10.5+" />
+
+```js
+// In your Vue component
+async created () {
+  const { Todo } = this.$FeathersVuex.api
+  const todosCount = await Todo.count()
+  // or
+  Todo.count().then((total) => { this.todoCount = total })
+}
+```
+
+### countInStore(params)
+
+Model classes have a `countInStore` method, which is a proxy to the [`count` getter](./service-plugin.html#Service-Getters).  <Badge text="3.10.5+" />
+
+```js
+// In your Vue component
+created () {
+  const { Todo } = this.$FeathersVuex.api
+  const todosCount = Todo.countInStore()
+}
+```
+
 ### get(id, params)
 
 Model classes have a `get` method, which is a proxy to the [`get` action](./service-plugin.html#get-id-or-get-id-params).   <Badge text="1.7.0+" /> Notice that the signature is more Feathers-like, and doesn't require using an array to passing both id and params.

--- a/docs/model-classes.md
+++ b/docs/model-classes.md
@@ -85,9 +85,11 @@ created () {
 }
 ```
 
-### count(params)
+### count(params) <Badge text="3.11.0+" />
 
-Model classes have a `count` method, which is a proxy to the [`find` action] with the param `$limit: 0` automaticalluy appended. On the Feathers server, `$limit: 0` results in a fast count query. (./service-plugin.html#find-params). <Badge text="3.10.5+" />
+Model classes have a `count` method, which is a proxy to the `count` action. On the Feathers server, `$limit: 0` results in a fast count query. (./service-plugin.html#find-params).
+
+> **Note:** it only works for services with enabled pagination!
 
 ```js
 // In your Vue component
@@ -99,9 +101,9 @@ async created () {
 }
 ```
 
-### countInStore(params)
+### countInStore(params) <Badge text="3.11.0+" />
 
-Model classes have a `countInStore` method, which is a proxy to the [`count` getter](./service-plugin.html#Service-Getters).  <Badge text="3.10.5+" />
+Model classes have a `countInStore` method, which is a proxy to the [`count` getter](./service-plugin.html#Service-Getters).
 
 ```js
 // In your Vue component

--- a/docs/service-plugin.md
+++ b/docs/service-plugin.md
@@ -199,7 +199,9 @@ Service modules include the following getters:
 
 - `list {Array}` - an array of items. The array form of `keyedById`  Read only.
 - `find(params) {Function}` - a helper function that allows you to use the [Feathers Adapter Common API](https://docs.feathersjs.com/api/databases/common) and [Query API](https://docs.feathersjs.com/api/databases/querying) to pull data from the store.  This allows you to treat the store just like a local Feathers database adapter (but without hooks).
-  - `params {Object}` - an object with a `query` object and an optional `paginate` boolean property. The `query` is in the FeathersJS query format.  You can set `params.paginate` to `false` to disable pagination for a single request.
+  - `params {Object}` - an object with a `query` object and optional `paginate` and `temps` boolean properties. The `query` is in the FeathersJS query format. You can set `params.paginate` to `false` to disable pagination for a single request.
+- `count(params) {Function}` - a helper function that counts items in the store matching the provided query in the params and returns this number <Badge text="3.11.0+" />
+  - `params {Object}` - an object with a `query` object and an optional `temps` boolean property.
 - `get(id[, params]) {Function}` - a function that allows you to query the store for a single item, by id.  It works the same way as `get` requests in Feathers database adapters.
   - `id {Number|String}` - the id of the data to be retrieved by id from the store.
   - `params {Object}` - an object containing a Feathers `query` object.
@@ -293,6 +295,21 @@ See the section about pagination, below, for more information that is applicable
 ### `afterFind(response)`
 
 The `afterFind` action is called by the `find` action after a successful response is added to the store.  It is called with the current response.  By default, it is a no-op (it literally does nothing), and is just a placeholder for you to use when necessary.  See the sections on [customizing the default store](#Customizing-a-Service’s-Default-Store) and [Handling custom server responses](./common-patterns.html#Handling-custom-server-responses) for example usage.
+
+### `count(params)` <Badge text="3.11.0+" />
+
+Count items on the server matching the provided query.
+
+- `params {Object}` - An object containing a `query` object. In the background `$limit: 0` will be added to the `query` to perform a (fast) counting query against the database.
+
+> **Note:** it only works for services with enabled pagination!
+
+```js
+let params = {query: {completed: false}}
+store.dispatch('todos/count', params)
+```
+
+This will run a (fast) counting query against the database and return a page object with the total and an empty data array.
 
 ### `get(id)` or `get([id, params])`
 

--- a/src/FeathersVuexCount.ts
+++ b/src/FeathersVuexCount.ts
@@ -1,0 +1,122 @@
+import { randomString } from './utils'
+
+export default {
+  props: {
+    service: {
+      type: String,
+      required: true
+    },
+    params: {
+      type: Object,
+      default: () => {
+        return {
+          query: {}
+        }
+      }
+    },
+    queryWhen: {
+      type: [Boolean, Function],
+      default: true
+    },
+    // If separate params are desired to fetch data, use fetchParams
+    // The watchers will automatically be updated, so you don't have to write 'fetchParams.query.propName'
+    fetchParams: {
+      type: Object
+    },
+    watch: {
+      type: [String, Array],
+      default: () => []
+    },
+    local: {
+      type: Boolean,
+      default: false
+    }
+  },
+  data: () => ({
+    isCountPending: false,
+    serverTotal: null
+  }),
+  computed: {
+    total() {
+      if (!this.local) {
+        return this.serverTotal
+      } else {
+        const { params, service, $store, temps } = this
+        return params ? $store.getters[`${service}/count`](params) : 0
+      }
+    },
+    scope() {
+      const { total, isCountPending } = this
+
+      return { total, isCountPending }
+    }
+  },
+  methods: {
+    findData() {
+      const params = this.fetchParams || this.params
+
+      if (
+        typeof this.queryWhen === 'function'
+          ? this.queryWhen(this.params)
+          : this.queryWhen
+      ) {
+        this.isCountPending = true
+
+        if (params) {
+          return this.$store
+            .dispatch(`${this.service}/count`, params)
+            .then(response => {
+              this.isCountPending = false
+              this.serverTotal = response
+            })
+        }
+      }
+    },
+    fetchData() {
+      if (!this.local) {
+        if (this.params) {
+          return this.findData()
+        } else {
+          // TODO: access debug boolean from the store config, somehow.
+          // eslint-disable-next-line no-console
+          console.log(
+            `No query and no id provided, so no data will be fetched.`
+          )
+        }
+      }
+    }
+  },
+  created() {
+    if (!this.$FeathersVuex) {
+      throw new Error(
+        `You must first Vue.use the FeathersVuex plugin before using the 'FeathersVuexFind' component.`
+      )
+    }
+    if (!this.$store.state[this.service]) {
+      throw new Error(
+        `The '${this.service}' plugin not registered with feathers-vuex`
+      )
+    }
+
+    const watch = Array.isArray(this.watch) ? this.watch : [this.watch]
+
+    if (this.fetchParams || this.params) {
+      watch.forEach(prop => {
+        if (typeof prop !== 'string') {
+          throw new Error(`Values in the 'watch' array must be strings.`)
+        }
+        if (this.fetchParams) {
+          if (prop.startsWith('params')) {
+            prop = prop.replace('params', 'fetchParams')
+          }
+        }
+        this.$watch(prop, this.fetchData)
+      })
+
+      this.fetchData()
+    }
+  },
+  render() {
+    return this.$scopedSlots.default(this.scope)
+  }
+}

--- a/src/service-module/make-base-model.ts
+++ b/src/service-module/make-base-model.ts
@@ -177,19 +177,13 @@ export default function makeBaseModel(options: FeathersVuexOptions) {
     }
 
     public static count(params) {
-      params = params || {
-        query: {} 
-      }
-      params.query.$limit = 0; // <- limit 0 in feathers is a fast count query
-      return this._dispatch('find', params).then((res) => {
-        return res.total
-      })
+      return this._dispatch('count', params)
     }
 
     public static countInStore(params) {
       return this._getters('count', params)
     }
-    
+
     public static get(id, params) {
       if (params) {
         return this._dispatch('get', [id, params])

--- a/src/service-module/make-base-model.ts
+++ b/src/service-module/make-base-model.ts
@@ -176,19 +176,21 @@ export default function makeBaseModel(options: FeathersVuexOptions) {
       return this._getters('find', params)
     }
 
-    public static count() {
-      const params = {
-        $limit: 0 // <- limit 0 in feathers is a fast count query
+    public static count(params) {
+      params = params || {
+        query: {}
       }
+      params.query.$limit = 0 // <- limit 0 in feathers is a fast count query
       return this._dispatch('find', params).then((res) => {
         return res.total
       })
     }
 
-    public static countInStore() {
-      return this._getters('count')
+    public static countInStore(params) {
+      console.log('params : ' + params)
+      return this._getters('count', params)
     }
-    
+
     public static get(id, params) {
       if (params) {
         return this._dispatch('get', [id, params])
@@ -250,7 +252,7 @@ export default function makeBaseModel(options: FeathersVuexOptions) {
       const state = store.state[namespace]
       const commit = store.commit
       // Replace each plain object with a model instance.
-      Object.keys(state.keyedById).forEach(id => {
+      Object.keys(state.keyedById).forEach((id) => {
         const record = state.keyedById[id]
         commit(`${namespace}/removeItem`, record)
         commit(`${namespace}/addItem`, record)

--- a/src/service-module/make-base-model.ts
+++ b/src/service-module/make-base-model.ts
@@ -176,21 +176,19 @@ export default function makeBaseModel(options: FeathersVuexOptions) {
       return this._getters('find', params)
     }
 
-    public static count(params) {
-      params = params || {
-        query: {}
+    public static count() {
+      const params = {
+        $limit: 0 // <- limit 0 in feathers is a fast count query
       }
-      params.query.$limit = 0 // <- limit 0 in feathers is a fast count query
       return this._dispatch('find', params).then((res) => {
         return res.total
       })
     }
 
-    public static countInStore(params) {
-      console.log('params : ' + params)
-      return this._getters('count', params)
+    public static countInStore() {
+      return this._getters('count')
     }
-
+    
     public static get(id, params) {
       if (params) {
         return this._dispatch('get', [id, params])
@@ -252,7 +250,7 @@ export default function makeBaseModel(options: FeathersVuexOptions) {
       const state = store.state[namespace]
       const commit = store.commit
       // Replace each plain object with a model instance.
-      Object.keys(state.keyedById).forEach((id) => {
+      Object.keys(state.keyedById).forEach(id => {
         const record = state.keyedById[id]
         commit(`${namespace}/removeItem`, record)
         commit(`${namespace}/addItem`, record)

--- a/src/service-module/make-base-model.ts
+++ b/src/service-module/make-base-model.ts
@@ -176,6 +176,19 @@ export default function makeBaseModel(options: FeathersVuexOptions) {
       return this._getters('find', params)
     }
 
+    public static count() {
+      const params = {
+        $limit: 0 // <- limit 0 in feathers is a fast count query
+      }
+      return this._dispatch('find', params).then((res) => {
+        return res.total
+      })
+    }
+
+    public static countInStore() {
+      return this._getters('count')
+    }
+    
     public static get(id, params) {
       if (params) {
         return this._dispatch('get', [id, params])

--- a/src/service-module/make-base-model.ts
+++ b/src/service-module/make-base-model.ts
@@ -176,17 +176,18 @@ export default function makeBaseModel(options: FeathersVuexOptions) {
       return this._getters('find', params)
     }
 
-    public static count() {
-      const params = {
-        $limit: 0 // <- limit 0 in feathers is a fast count query
+    public static count(params) {
+      params = params || {
+        query: {} 
       }
+      params.query.$limit = 0; // <- limit 0 in feathers is a fast count query
       return this._dispatch('find', params).then((res) => {
         return res.total
       })
     }
 
-    public static countInStore() {
-      return this._getters('count')
+    public static countInStore(params) {
+      return this._getters('count', params)
     }
     
     public static get(id, params) {

--- a/src/service-module/service-module.actions.ts
+++ b/src/service-module/service-module.actions.ts
@@ -50,7 +50,7 @@ export default function makeServiceActions(service: Service<any>) {
         commit('setPending', 'get')
         return service
           .get(id, params)
-          .then(async function(item) {
+          .then(async function (item) {
             dispatch('addOrUpdate', item)
             commit('unsetPending', 'get')
             return state.keyedById[id]
@@ -134,7 +134,7 @@ export default function makeServiceActions(service: Service<any>) {
 
       return service
         .update(id, data, params)
-        .then(async function(item) {
+        .then(async function (item) {
           dispatch('addOrUpdate', item)
           commit('unsetPending', 'update')
           return state.keyedById[id]
@@ -164,7 +164,7 @@ export default function makeServiceActions(service: Service<any>) {
 
       return service
         .patch(id, data, params)
-        .then(async function(item) {
+        .then(async function (item) {
           dispatch('addOrUpdate', item)
           commit('unsetPending', 'patch')
           return state.keyedById[id]
@@ -208,6 +208,22 @@ export default function makeServiceActions(service: Service<any>) {
   }
 
   const actions = {
+    count({ dispatch }, params) {
+      params = params || {}
+      params = fastCopy(params)
+
+      if (!params.query) {
+        throw 'params must contain a query-object'
+      }
+
+      params.query.$limit = 0 // <- limit 0 in feathers is a fast count query
+
+      return dispatch('find', params)
+        .then(response => {
+          return response.total || response.length
+        })
+        .catch(error => dispatch('handleFindError', { params, error }))
+    },
     /**
      * Handle the response from the find action.
      *

--- a/src/service-module/service-module.getters.ts
+++ b/src/service-module/service-module.getters.ts
@@ -81,9 +81,7 @@ export default function makeServiceGetters() {
         throw 'params must contain a query-object'
       }
 
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      const { $sort, $limit, $skip, $select, ...cleanQuery } = params.query
-
+      const cleanQuery = _omit(params.query, FILTERS)
       params.query = cleanQuery
 
       return getters.find(state)(params).total

--- a/src/service-module/service-module.getters.ts
+++ b/src/service-module/service-module.getters.ts
@@ -19,9 +19,12 @@ const defaultOps = FILTERS.concat(OPERATORS).concat(additionalOperators)
 export default function makeServiceGetters() {
   return {
     list(state) {
-      return state.ids.map((id) => state.keyedById[id])
+      return state.ids.map(id => state.keyedById[id])
     },
-    count: (state) => (params) => {
+    count: state => () => {
+      return state.ids.length;
+    },
+    find: state => params => {
       if (isRef(params)) {
         params = params.value
       }
@@ -33,7 +36,7 @@ export default function makeServiceGetters() {
       const { paramsForServer, whitelist, keyedById } = state
       const q = _omit(params.query || {}, paramsForServer)
       const customOperators = Object.keys(q).filter(
-        (k) => k[0] === '$' && !defaultOps.includes(k)
+        k => k[0] === '$' && !defaultOps.includes(k)
       )
       const cleanQuery = _omit(q, customOperators)
 
@@ -63,58 +66,7 @@ export default function makeServiceGetters() {
       }
 
       if (filters.$select) {
-        values = values.map((value) =>
-          _.pick(value, ...filters.$select.slice())
-        )
-      }
-
-      return total
-    },
-    find: (state) => (params) => {
-      if (isRef(params)) {
-        params = params.value
-      }
-      params = { ...params } || {}
-
-      // Set params.temps to true to include the tempsById records
-      params.temps = params.hasOwnProperty('temps') ? params.temps : false
-
-      const { paramsForServer, whitelist, keyedById } = state
-      const q = _omit(params.query || {}, paramsForServer)
-      const customOperators = Object.keys(q).filter(
-        (k) => k[0] === '$' && !defaultOps.includes(k)
-      )
-      const cleanQuery = _omit(q, customOperators)
-
-      const { query, filters } = filterQuery(cleanQuery, {
-        operators: additionalOperators.concat(whitelist)
-      })
-      let values = _.values(keyedById)
-
-      if (params.temps) {
-        values = values.concat(_.values(state.tempsById))
-      }
-
-      values = values.filter(sift(query))
-
-      const total = values.length
-
-      if (filters.$sort) {
-        values.sort(sorter(filters.$sort))
-      }
-
-      if (filters.$skip) {
-        values = values.slice(filters.$skip)
-      }
-
-      if (typeof filters.$limit !== 'undefined') {
-        values = values.slice(0, filters.$limit)
-      }
-
-      if (filters.$select) {
-        values = values.map((value) =>
-          _.pick(value, ...filters.$select.slice())
-        )
+        values = values.map(value => _.pick(value, ...filters.$select.slice()))
       }
 
       return {
@@ -137,7 +89,7 @@ export default function makeServiceGetters() {
 
       return tempRecord || null
     },
-    getCopyById: (state) => (id) => {
+    getCopyById: state => id => {
       const { servicePath, keepCopiesInStore, serverAlias } = state
 
       if (keepCopiesInStore) {

--- a/src/service-module/service-module.getters.ts
+++ b/src/service-module/service-module.getters.ts
@@ -21,6 +21,9 @@ export default function makeServiceGetters() {
     list(state) {
       return state.ids.map(id => state.keyedById[id])
     },
+    count: state => () => {
+      return state.ids.length;
+    },
     find: state => params => {
       if (isRef(params)) {
         params = params.value

--- a/src/service-module/service-module.getters.ts
+++ b/src/service-module/service-module.getters.ts
@@ -21,35 +21,6 @@ export default function makeServiceGetters() {
     list(state) {
       return state.ids.map(id => state.keyedById[id])
     },
-    count: state => params => {
-      if (isRef(params)) {
-        params = params.value
-      }
-      params = { ...params } || {}
-
-      // Set params.temps to true to include the tempsById records
-      params.temps = params.hasOwnProperty('temps') ? params.temps : false
-
-      const { paramsForServer, whitelist, keyedById } = state
-      const q = _omit(params.query || {}, paramsForServer)
-      const customOperators = Object.keys(q).filter(
-        k => k[0] === '$' && !defaultOps.includes(k)
-      )
-      const cleanQuery = _omit(q, customOperators)
-
-      const { query, filters } = filterQuery(cleanQuery, {
-        operators: additionalOperators.concat(whitelist)
-      })
-      let values = _.values(keyedById)
-
-      if (params.temps) {
-        values = values.concat(_.values(state.tempsById))
-      }
-
-      values = values.filter(sift(query))
-
-      return values.length
-    },
     find: state => params => {
       if (isRef(params)) {
         params = params.value
@@ -101,6 +72,9 @@ export default function makeServiceGetters() {
         skip: filters.$skip || 0,
         data: values
       }
+    },
+    count: (state, getters) => params => {
+      return getters.find(state)(params).total
     },
     get: ({ keyedById, tempsById, idField, tempIdField }) => (
       id,

--- a/src/service-module/service-module.getters.ts
+++ b/src/service-module/service-module.getters.ts
@@ -74,6 +74,18 @@ export default function makeServiceGetters() {
       }
     },
     count: (state, getters) => params => {
+      if (isRef(params)) {
+        params = params.value
+      }
+      if (!params.query) {
+        throw 'params must contain a query-object'
+      }
+
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      const { $sort, $limit, $skip, $select, ...cleanQuery } = params.query
+
+      params.query = cleanQuery
+
       return getters.find(state)(params).total
     },
     get: ({ keyedById, tempsById, idField, tempIdField }) => (

--- a/src/vue-plugin/vue-plugin.ts
+++ b/src/vue-plugin/vue-plugin.ts
@@ -8,6 +8,7 @@ import FeathersVuexGet from '../FeathersVuexGet'
 import FeathersVuexFormWrapper from '../FeathersVuexFormWrapper'
 import FeathersVuexInputWrapper from '../FeathersVuexInputWrapper'
 import FeathersVuexPagination from '../FeathersVuexPagination'
+import FeathersVuexCount from '../FeathersVuexCount'
 import { globalModels } from '../service-module/global-models'
 
 export const FeathersVuex = {
@@ -23,6 +24,7 @@ export const FeathersVuex = {
       Vue.component('FeathersVuexFormWrapper', FeathersVuexFormWrapper)
       Vue.component('FeathersVuexInputWrapper', FeathersVuexInputWrapper)
       Vue.component('FeathersVuexPagination', FeathersVuexPagination)
+      Vue.component('FeathersVuexCount', FeathersVuexCount)
     }
   }
 }

--- a/test/service-module/model-base.test.ts
+++ b/test/service-module/model-base.test.ts
@@ -60,6 +60,8 @@ describe('makeModel / BaseModel', function () {
       'getId',
       'find',
       'findInStore',
+      'count',
+      'countInStore',
       'get',
       'getFromStore'
     ]

--- a/test/service-module/model-methods.test.ts
+++ b/test/service-module/model-methods.test.ts
@@ -155,6 +155,27 @@ describe('Models - Methods', function() {
     assert(typeof Task.findInStore === 'function')
   })
 
+  it('Model.count is a function', function() {
+    const { Task } = makeContext()
+
+    assert(typeof Task.count === 'function')
+  })
+
+  it('Model.count returns a Promise', function() {
+    const { Task } = makeContext()
+    const result = Task.count()
+    assert(typeof result.then !== 'undefined')
+    result.catch(err => {
+      /* noop -- prevents UnhandledPromiseRejectionWarning */
+    })
+  })
+
+  it('Model.countInStore', function() {
+    const { Task } = makeContext()
+
+    assert(typeof Task.countInStore === 'function')
+  })
+
   it('Model.get', function() {
     const { Task } = makeContext()
 

--- a/test/service-module/model-methods.test.ts
+++ b/test/service-module/model-methods.test.ts
@@ -129,18 +129,18 @@ function makeContext() {
 
 export { makeContext }
 
-describe('Models - Methods', function() {
+describe('Models - Methods', function () {
   beforeEach(() => {
     clearModels()
   })
 
-  it('Model.find is a function', function() {
+  it('Model.find is a function', function () {
     const { Task } = makeContext()
 
     assert(typeof Task.find === 'function')
   })
 
-  it('Model.find returns a Promise', function() {
+  it('Model.find returns a Promise', function () {
     const { Task } = makeContext()
     const result = Task.find()
     assert(typeof result.then !== 'undefined')
@@ -149,46 +149,46 @@ describe('Models - Methods', function() {
     })
   })
 
-  it('Model.findInStore', function() {
+  it('Model.findInStore', function () {
     const { Task } = makeContext()
 
     assert(typeof Task.findInStore === 'function')
   })
 
-  it('Model.count is a function', function() {
+  it('Model.count is a function', function () {
     const { Task } = makeContext()
 
     assert(typeof Task.count === 'function')
   })
 
-  it('Model.count returns a Promise', function() {
+  it('Model.count returns a Promise', function () {
     const { Task } = makeContext()
-    const result = Task.count()
+    const result = Task.count({ query: {} })
     assert(typeof result.then !== 'undefined')
     result.catch(err => {
       /* noop -- prevents UnhandledPromiseRejectionWarning */
     })
   })
 
-  it('Model.countInStore', function() {
+  it('Model.countInStore', function () {
     const { Task } = makeContext()
 
     assert(typeof Task.countInStore === 'function')
   })
 
-  it('Model.get', function() {
+  it('Model.get', function () {
     const { Task } = makeContext()
 
     assert(typeof Task.get === 'function')
   })
 
-  it('Model.getFromStore', function() {
+  it('Model.getFromStore', function () {
     const { Task } = makeContext()
 
     assert(typeof Task.getFromStore === 'function')
   })
 
-  it('allows listening to Feathers events on Model', function(done) {
+  it('allows listening to Feathers events on Model', function (done) {
     const { Letter } = makeContext()
 
     Letter.on('created', data => {
@@ -203,7 +203,7 @@ describe('Models - Methods', function() {
     }).save()
   })
 
-  it('instance.save calls create with correct arguments', function() {
+  it('instance.save calls create with correct arguments', function () {
     const { Task } = makeContext()
     const task = new Task({ test: true })
 
@@ -220,7 +220,7 @@ describe('Models - Methods', function() {
     task.save()
   })
 
-  it('instance.save passes params to create', function() {
+  it('instance.save passes params to create', function () {
     const { Task } = makeContext()
     const task = new Task({ test: true })
     let called = false
@@ -237,7 +237,7 @@ describe('Models - Methods', function() {
     assert(called, 'create should have been called')
   })
 
-  it('instance.save passes params to patch', function() {
+  it('instance.save passes params to patch', function () {
     const { Todo } = makeContext()
     const todo = new Todo({ id: 1, test: true })
     let called = false
@@ -254,7 +254,7 @@ describe('Models - Methods', function() {
     assert(called, 'patch should have been called')
   })
 
-  it('instance.save passes params to update', function() {
+  it('instance.save passes params to update', function () {
     const { Task } = makeContext()
     Task.preferUpdate = true
 
@@ -273,7 +273,7 @@ describe('Models - Methods', function() {
     assert(called, 'update should have been called')
   })
 
-  it('instance.remove works with temp records', function() {
+  it('instance.remove works with temp records', function () {
     const { Task, store } = makeContext()
     const task = new Task({ test: true })
     const tempId = task.__id
@@ -284,11 +284,11 @@ describe('Models - Methods', function() {
     assert(!store.state.tasks.tempsById[tempId], 'temp was removed')
   })
 
-  it.skip('instance.remove removes cloned records from the store', function() {})
-  it.skip('instance.remove removes cloned records from the Model.copiesById', function() {})
-  it.skip('removes clone and original upon calling clone.remove()', function() {})
+  it.skip('instance.remove removes cloned records from the store', function () {})
+  it.skip('instance.remove removes cloned records from the Model.copiesById', function () {})
+  it.skip('removes clone and original upon calling clone.remove()', function () {})
 
-  it('instance methods still available in store data after updateItem mutation (or socket event)', async function() {
+  it('instance methods still available in store data after updateItem mutation (or socket event)', async function () {
     const { Letter, store, lettersService } = makeContext()
     let letter = new Letter({ name: 'Garmadon', age: 1025 })
 
@@ -319,7 +319,7 @@ describe('Models - Methods', function() {
     )
   })
 
-  it('Dates remain as dates after changes', async function() {
+  it('Dates remain as dates after changes', async function () {
     const { Letter, store, lettersService } = makeContext()
     let letter = new Letter({
       name: 'Garmadon',
@@ -336,7 +336,7 @@ describe('Models - Methods', function() {
     assert(isDate(letter.createdAt), 'createdAt should be a date')
   })
 
-  it('instance.toJSON', function() {
+  it('instance.toJSON', function () {
     const { Task } = makeContext()
     const task = new Task({ id: 1, test: true })
 

--- a/test/service-module/module.getters.test.ts
+++ b/test/service-module/module.getters.test.ts
@@ -21,11 +21,11 @@ const options = {
   service: null
 }
 
-const { find, list, get, getCopyById } = makeServiceGetters()
+const { find, count, list, get, getCopyById } = makeServiceGetters()
 const { addItems } = makeServiceMutations()
 
-describe('Service Module - Getters', function() {
-  beforeEach(function() {
+describe('Service Module - Getters', function () {
+  beforeEach(function () {
     const state = makeServiceState(options)
     this.items = [
       {
@@ -63,7 +63,7 @@ describe('Service Module - Getters', function() {
     this.state = state
   })
 
-  it('list', function() {
+  it('list', function () {
     const { state, items } = this
     const results = list(state)
 
@@ -74,7 +74,7 @@ describe('Service Module - Getters', function() {
     })
   })
 
-  it('getCopyById with keepCopiesInStore: true', function() {
+  it('getCopyById with keepCopiesInStore: true', function () {
     const state = {
       keepCopiesInStore: true,
       copiesById: {
@@ -88,7 +88,7 @@ describe('Service Module - Getters', function() {
     assert(result.test, 'got the copy')
   })
 
-  it('getCopyById with keepCopiesInStore: false', function() {
+  it('getCopyById with keepCopiesInStore: false', function () {
     const state = {
       keepCopiesInStore: false,
       servicePath: 'todos',
@@ -117,7 +117,7 @@ describe('Service Module - Getters', function() {
     clearModels()
   })
 
-  it('get works on keyedById', function() {
+  it('get works on keyedById', function () {
     const { state, items } = this
     // @ts-ignore
     const result = get(state)(1)
@@ -126,7 +126,7 @@ describe('Service Module - Getters', function() {
     assert.deepEqual(result, items[0])
   })
 
-  it('get works on tempsById', function() {
+  it('get works on tempsById', function () {
     const { state } = this
     const tempId = Object.keys(state.tempsById)[0]
     // @ts-ignore
@@ -136,7 +136,7 @@ describe('Service Module - Getters', function() {
     assert(result.__id === tempId)
   })
 
-  it('find - no temps by default', function() {
+  it('find - no temps by default', function () {
     const { state, items } = this
     const params = { query: {} }
     const results = find(state)(params)
@@ -151,7 +151,7 @@ describe('Service Module - Getters', function() {
     assert(results.total === 3, 'total was correct')
   })
 
-  it('find with temps', function() {
+  it('find with temps', function () {
     const { state, items } = this
     // Set temps: false to skip the temps.
     const params = { query: {}, temps: true }
@@ -163,7 +163,7 @@ describe('Service Module - Getters', function() {
     assert(results.total === 4, 'total was correct')
   })
 
-  it('find with query', function() {
+  it('find with query', function () {
     const { state } = this
     const params = { query: { test: false } }
     const results = find(state)(params)
@@ -175,7 +175,7 @@ describe('Service Module - Getters', function() {
     assert(results.total === 1, 'total was correct')
   })
 
-  it('find with custom operator', function() {
+  it('find with custom operator', function () {
     const { state } = this
     const params = { query: { test: false, $populateQuery: 'test' } }
     const results = find(state)(params)
@@ -187,7 +187,7 @@ describe('Service Module - Getters', function() {
     assert(results.total === 1, 'total was correct')
   })
 
-  it('find with paramsForServer option', function() {
+  it('find with paramsForServer option', function () {
     const { state } = this
     state.paramsForServer = ['_$client']
     const params = { query: { test: false, _$client: 'test' } }
@@ -200,7 +200,7 @@ describe('Service Module - Getters', function() {
     assert(results.total === 1, 'total was correct')
   })
 
-  it('find with non-whitelisted custom operator fails', function() {
+  it('find with non-whitelisted custom operator fails', function () {
     const { state } = this
     const params = { query: { $client: 'test' } }
     let results
@@ -212,7 +212,7 @@ describe('Service Module - Getters', function() {
     assert(!results[0])
   })
 
-  it('find with whitelisted custom operators', function() {
+  it('find with whitelisted custom operators', function () {
     const { state } = this
     state.whitelist = ['$regex', '$options']
     const query = {
@@ -232,7 +232,7 @@ describe('Service Module - Getters', function() {
     assert(results.total === 1, 'total was correct')
   })
 
-  it('find works with $elemMatch', function() {
+  it('find works with $elemMatch', function () {
     const { state } = this
     const query = {
       movies: {
@@ -249,7 +249,7 @@ describe('Service Module - Getters', function() {
     assert(results.total === 1, 'total was correct')
   })
 
-  it('find with limit', function() {
+  it('find with limit', function () {
     const { state } = this
     const params = { query: { $limit: 1 } }
     const results = find(state)(params)
@@ -261,7 +261,7 @@ describe('Service Module - Getters', function() {
     assert(results.total === 3, 'total was correct')
   })
 
-  it('find with skip', function() {
+  it('find with skip', function () {
     const { state } = this
     const params = { query: { $skip: 1 } }
     const results = find(state)(params)
@@ -274,7 +274,7 @@ describe('Service Module - Getters', function() {
     assert(results.total === 3, 'total was correct')
   })
 
-  it('find with limit and skip', function() {
+  it('find with limit and skip', function () {
     const { state } = this
     const params = { query: { $limit: 1, $skip: 1 } }
     const results = find(state)(params)
@@ -286,7 +286,7 @@ describe('Service Module - Getters', function() {
     assert(results.total === 3, 'total was correct')
   })
 
-  it('find with select', function() {
+  it('find with select', function () {
     const { state } = this
     const params = { query: { $select: ['otherField'] } }
     const results = find(state)(params)
@@ -305,7 +305,7 @@ describe('Service Module - Getters', function() {
     assert(results.total === 3, 'total was correct')
   })
 
-  it('find with sort ascending on integers', function() {
+  it('find with sort ascending on integers', function () {
     const { state } = this
     const params = {
       query: {
@@ -322,7 +322,7 @@ describe('Service Module - Getters', function() {
       }, 0)
   })
 
-  it('find with sort descending on integers', function() {
+  it('find with sort descending on integers', function () {
     const { state } = this
     const params = {
       query: {
@@ -339,7 +339,7 @@ describe('Service Module - Getters', function() {
       }, 100)
   })
 
-  it('find with sort ascending on floats', function() {
+  it('find with sort ascending on floats', function () {
     const { state } = this
     const params = {
       query: {
@@ -359,7 +359,7 @@ describe('Service Module - Getters', function() {
       }, 0)
   })
 
-  it('find with sort descending on floats', function() {
+  it('find with sort descending on floats', function () {
     const { state } = this
     const params = {
       query: {
@@ -377,5 +377,32 @@ describe('Service Module - Getters', function() {
         )
         return current
       }, 100)
+  })
+
+  it('count without params fails', function () {
+    const { state } = this
+
+    try {
+      count(state, { find })(null)
+    } catch (error) {
+      assert(error)
+    }
+  })
+
+  it('count without query fails', function () {
+    const { state } = this
+
+    try {
+      count(state, { find })({})
+    } catch (error) {
+      assert(error)
+    }
+  })
+
+  it('count returns the number of records in the store', function () {
+    const { state } = this
+
+    const total = count(state, { find })({ query: {} })
+    assert(total === 3, 'count is 3')
   })
 })

--- a/test/service-module/service-module.actions.test.ts
+++ b/test/service-module/service-module.actions.test.ts
@@ -612,7 +612,49 @@ describe('Service Module - Actions', () => {
     })
   })
 
-  describe('Get', function() {
+  describe('Count', () => {
+    it('count without params fails', done => {
+      const { makeServicePlugin, Task } = makeContext()
+      const store = new Vuex.Store<RootState>({
+        plugins: [
+          makeServicePlugin({
+            servicePath: 'my-tasks',
+            Model: Task,
+            service: feathersClient.service('my-tasks')
+          })
+        ]
+      })
+      const actions = mapActions('my-tasks', ['count'])
+
+      try {
+        actions.count.call({ $store: store })
+      } catch (err) {
+        assert(err)
+        done()
+      }
+    })
+
+    it('count with query returns number', done => {
+      const { makeServicePlugin, Task } = makeContext()
+      const store = new Vuex.Store<RootState>({
+        plugins: [
+          makeServicePlugin({
+            servicePath: 'my-tasks',
+            Model: Task,
+            service: feathersClient.service('my-tasks')
+          })
+        ]
+      })
+      const actions = mapActions('my-tasks', ['count'])
+
+      actions.count.call({ $store: store }, { query: {} }).then(response => {
+        assert(response === 10, 'total is 10')
+        done()
+      })
+    })
+  })
+
+  describe('Get', function () {
     it('updates store list state on service success', async () => {
       const { makeServicePlugin, Todo } = makeContext()
       const store = new Vuex.Store<RootState>({
@@ -793,7 +835,7 @@ describe('Service Module - Actions', () => {
     })
   })
 
-  describe('Create', function() {
+  describe('Create', function () {
     it('updates store list state on service success', done => {
       const { makeServicePlugin, Todo } = makeContext()
       const store = new Vuex.Store<RootState>({


### PR DESCRIPTION
### Summary

This is a replacement to #483 from @tylermmorton because there was no activity recently.

### What is this about?

Feathers.js provides a fast count query by adding `$limit: 0` to the query which is widely unknown. The proposed changes to Feathes-Vuex enable an easy and convenient way to count items on the server or store
> Pro tip: With pagination enabled, to just get the number of available records set `$limit` to `0`. This will only run a (fast) counting query against the database and return a page object with the `total` and an empty `data` array.`
https://docs.feathersjs.com/api/databases/querying.html#limit

### How is this different from #483?

**What #483 does:**
- adds the Model methods `count` and `countInStore` where the last one is a monkeypatch to the `count`-getter.
- adds tests for these two methods
- add docs for these two methods

**What this PR does:**
- add `count` getter and `count` action to service plugin
- add static `count` and `countInStore` methods to Models
- add `<FeathersVuexCount>` renderless data component for a fast way to show counts in `<template>`
- add tests for getter, action & Model-methods
- add docs for getter, action, Model-methods & renderless data components with a **v3.11.0 badge**

### But wait, there are a lot of changes in the renderless data components docs?!

As I added the third renderless data component it became difficult to remain simpleness with the existing structure:
- So now the components have individual **props** and **scope data**. It's longer but much easier to read
- changed the `slot-scope=""` on child to `v-slot=""` on parent since `slot-scope=""` is deprecated as of `vue^2.6.0` https://vuejs.org/v2/guide/components-slots.html#Scoped-Slots
- `<FeathersVuexGet>` has `params` and `fetchParams` beside `query` and `fetchQuery`. So I added it to `<FeathersVuexFind>` as well. Since the mixins and the composition API only use `params` instead of `query` it felt natural to me to **deprecate** the `query` related attributes. I documented it in the docs but it's a discussable step. The reason for `params` is it enables more flexibility, e.g. for `$populateParams`
- `<FeathersVuexCount>` only has `params` and no ``query` to keep the consistency with mixins and the composition API
- the `temps` attribute for `<FeathersVuexFind>` also gets deprecated because it gets replaced by `:params="{ query: {}, temps: true }"`

The changes got more than I thought but while programming there came more and more things along the way which felt like to they need to be pulled straight. 
@marshallswain if the `params` for `<FeathersVuexFind>` and the deprecations don't feel right to you, I will change it back. I would be happy to discuss these steps :)

Closes #483