### PR TITLE
Ts/ref typing

### DIFF
--- a/src/service-module/service-module.getters.ts
+++ b/src/service-module/service-module.getters.ts
@@ -89,6 +89,9 @@ export default function makeServiceGetters() {
       if (isRef(id)) {
         id = id.value
       }
+      if (isRef(params)) {
+        params = params.value
+      }
       const record = keyedById[id] && select(params, idField)(keyedById[id])
       if (record) {
         return record

--- a/src/service-module/types.ts
+++ b/src/service-module/types.ts
@@ -2,6 +2,7 @@ import { Service, Id } from '@feathersjs/feathers'
 import { Params, Paginated } from '../utils'
 import { EventEmitter } from 'events'
 import { Store } from 'vuex'
+import { Ref } from '@vue/composition-api'
 
 export { Id } from '@feathersjs/feathers'
 
@@ -244,7 +245,7 @@ export interface ModelStatic extends EventEmitter {
    * A proxy for the `find` getter
    * @param params Find params
    */
-  findInStore<M extends Model = Model>(params?: Params): Paginated<M>
+  findInStore<M extends Model = Model>(params?: Params | Ref<Params>): Paginated<M>
 
   /**
    * A proxy for the `count` action
@@ -255,7 +256,7 @@ export interface ModelStatic extends EventEmitter {
    * A proxy for the `count` getter
    * @param params Find params
    */
-  countInStore(params?: Params): number
+  countInStore(params?: Params | Ref<Params>): number
 
   /**
    * A proxy for the `get` action
@@ -268,7 +269,7 @@ export interface ModelStatic extends EventEmitter {
    * @param id ID of record to retrieve
    * @param params Get params
    */
-  getFromStore<M extends Model = Model>(id: Id, params?: Params): M | undefined
+  getFromStore<M extends Model = Model>(id: Id | Ref<Id>, params?: Params | Ref<Params>): M | undefined
 }
 
 /** Model instance interface */

--- a/src/service-module/types.ts
+++ b/src/service-module/types.ts
@@ -250,12 +250,12 @@ export interface ModelStatic extends EventEmitter {
    * A proxy for the `count` action
    * @param params Find params
    */
-  count<M extends Model = Model>(params?: Params): Promise<M[] | Paginated<M>>
+  count(params?: Params): Promise<number>
   /**
    * A proxy for the `count` getter
    * @param params Find params
    */
-  countInStore<M extends Model = Model>(params?: Params): Paginated<M>
+  countInStore(params?: Params): number
 
   /**
    * A proxy for the `get` action


### PR DESCRIPTION
### Summary

Three tiny changes

- Fixes `count` and `countInStore` typing to return `number`
- Allows `params` to be passed as `Ref` in `get` getter
- Adds `Ref` args to `*InStore` Model functions

❤️ 