### PR TITLE
Feature: per-instance pending status

### DIFF
--- a/docs/model-classes.md
+++ b/docs/model-classes.md
@@ -339,7 +339,9 @@ const todo = new Todo({ description: 'Do something!' })
 
 The examples above show instantiating a new Model instance without an `id` field. In this case, the record is not added to the Vuex store.  If you instantiate a record **with an `id`** field, it **will** get added to the Vuex store. *Note: This field is customizable using the `idField` option for this service.*
 
-Now that we have Model instances, let's take a look at the functionality they provide. Each instance will include the following methods:
+Now that we have Model instances, let's take a look at the functionality they provide.
+
+Each instance will include the following methods:
 
 - `.save()`
 - `.create()`
@@ -348,6 +350,15 @@ Now that we have Model instances, let's take a look at the functionality they pr
 - `.clone()`
 - `.commit()`
 - `.reset()`
+
+and the following readonly attributes:
+
+- `isCreatePending` - `create` is currently pending on this model
+- `isUpdatePending` - `update` is currently pending on this model
+- `isPatchPending` - `patch` is currently pending on this model
+- `isRemovePending` - `remove` is currently pending on this model
+- `isSavePending` - Any of `create`, `update` or `patch` is currently pending on this model
+- `isPending` - Any method is currently pending on this model
 
 *Remember, if a record already has an attribute with any of these method names, it will be overwritten with the method.*
 

--- a/docs/service-plugin.md
+++ b/docs/service-plugin.md
@@ -156,7 +156,12 @@ Each service comes loaded with the following default state:
     errorOnCreate: undefined,
     errorOnUpdate: undefined,
     errorOnPatch: undefined,
-    errorOnRemove: undefined
+    errorOnRemove: undefined,
+
+    isIdCreatePending: [],
+    isIdUpdatePending: [],
+    isIdPatchPending: [],
+    isIdRemovePending: [],
   }
 ```
 
@@ -193,6 +198,13 @@ The following state attribute will be populated with any request error, serializ
 - `errorOnPatch {Error}`
 - `errorOnRemo {Error}`
 
+The following state attributes allow you to bind to the pending state of requests *per item ID*
+
+- `isIdCreatePending {Array}` - Contains `id` if there's a pending `create` request for `id`.
+- `isIdUpdatePending {Array}` -Contains `id` if there's a pending `update` request for `id`.
+- `isIdPatchPending {Array}` - Contains `id` if there's a pending `patch` request for `id`.
+- `isIdRemovePending {Array}` - Contains `id` if there's a pending `remove` request for `id`.
+
 ## Service Getters
 
 Service modules include the following getters:
@@ -205,6 +217,15 @@ Service modules include the following getters:
 - `get(id[, params]) {Function}` - a function that allows you to query the store for a single item, by id.  It works the same way as `get` requests in Feathers database adapters.
   - `id {Number|String}` - the id of the data to be retrieved by id from the store.
   - `params {Object}` - an object containing a Feathers `query` object.
+
+The following getters ease access to per-instance pending status
+
+- `isCreatePendingById(id) {Function}` - Check if `create` is pending for `id`
+- `isUpdatePendingById(id) {Function}` - Check if `update` is pending for `id`
+- `isPatchPendingById(id) {Function}` - Check if `patch` is pending for `id`
+- `isRemovePendingById(id) {Function}` - Check if `remove` is pending for `id`
+- `isSavePendingById(id) {Function}` - Check if `create`, `update`, or `patch` is pending for `id`
+- `isPendingById(id) {Function}` - Check if `create`, `update`, `patch` or `remove` is pending for `id`
 
 ## Service Mutations
 
@@ -262,7 +283,9 @@ Clears all data from `ids`, `keyedById`, and `currentId`
 The following mutations are called automatically by the service actions, and will rarely, if ever, need to be used manually.
 
 - `setPending(state, method)` - sets the `is${method}Pending` attribute to true
+- `setIdPending(state, { method, id })` - adds `id` to `isId${method}Pending` array
 - `unsetPending(state, method)` - sets the `is${method}Pending` attribute to false
+- `unsetIdPending(state, { method, id })` - removes `id` from `isId${method}Pending` array
 
 ### Mutations for Managing Errors
 

--- a/src/service-module/make-base-model.ts
+++ b/src/service-module/make-base-model.ts
@@ -200,6 +200,9 @@ export default function makeBaseModel(options: FeathersVuexOptions) {
     get isRemovePending(): boolean {
       return this.getGetterWithId('isRemovePendingById') as boolean
     }
+    get isSavePending(): boolean {
+      return this.getGetterWithId('isSavePendingById') as boolean
+    }
     get isPending(): boolean {
       return this.getGetterWithId('isPendingById') as boolean
     }

--- a/src/service-module/service-module.actions.ts
+++ b/src/service-module/service-module.actions.ts
@@ -99,6 +99,7 @@ export default function makeServiceActions(service: Service<any>) {
       params = params || {}
 
       commit('setPending', 'create')
+      commit('setIdPending', { method: 'create', id: tempIds })
 
       return service
         .create(data, params)
@@ -121,19 +122,22 @@ export default function makeServiceActions(service: Service<any>) {
 
             // response = state.keyedById[id]
           }
-          commit('unsetPending', 'create')
           commit('removeTemps', tempIds)
           return response
         })
         .catch(error => {
           commit('setError', { method: 'create', error })
-          commit('unsetPending', 'create')
           return Promise.reject(error)
+        })
+        .finally(() => {
+          commit('unsetPending', 'create')
+          commit('unsetIdPending', { method: 'create', id: tempIds })
         })
     },
 
     update({ commit, dispatch, state }, [id, data, params]) {
       commit('setPending', 'update')
+      commit('setIdPending', { method: 'update', id })
 
       params = fastCopy(params)
 
@@ -141,13 +145,15 @@ export default function makeServiceActions(service: Service<any>) {
         .update(id, data, params)
         .then(async function (item) {
           dispatch('addOrUpdate', item)
-          commit('unsetPending', 'update')
           return state.keyedById[id]
         })
         .catch(error => {
           commit('setError', { method: 'update', error })
-          commit('unsetPending', 'update')
           return Promise.reject(error)
+        })
+        .finally(() => {
+          commit('unsetPending', 'update')
+          commit('unsetIdPending', { method: 'update', id })
         })
     },
 
@@ -157,6 +163,7 @@ export default function makeServiceActions(service: Service<any>) {
      */
     patch({ commit, dispatch, state }, [id, data, params]) {
       commit('setPending', 'patch')
+      commit('setIdPending', { method: 'patch', id })
 
       params = fastCopy(params)
 
@@ -171,13 +178,15 @@ export default function makeServiceActions(service: Service<any>) {
         .patch(id, data, params)
         .then(async function (item) {
           dispatch('addOrUpdate', item)
-          commit('unsetPending', 'patch')
           return state.keyedById[id]
         })
         .catch(error => {
           commit('setError', { method: 'patch', error })
-          commit('unsetPending', 'patch')
           return Promise.reject(error)
+        })
+        .finally(() => {
+          commit('unsetPending', 'patch')
+          commit('unsetIdPending', { method: 'patch', id })
         })
     },
 
@@ -196,18 +205,21 @@ export default function makeServiceActions(service: Service<any>) {
       params = fastCopy(params)
 
       commit('setPending', 'remove')
+      commit('setIdPending', { method: 'remove', id })
 
       return service
         .remove(id, params)
         .then(item => {
           commit('removeItem', id)
-          commit('unsetPending', 'remove')
           return item
         })
         .catch(error => {
           commit('setError', { method: 'remove', error })
-          commit('unsetPending', 'remove')
           return Promise.reject(error)
+        })
+        .finally(() => {
+          commit('unsetPending', 'remove')
+          commit('unsetIdPending', { method: 'remove', id })
         })
     }
   }

--- a/src/service-module/service-module.getters.ts
+++ b/src/service-module/service-module.getters.ts
@@ -10,6 +10,8 @@ import { globalModels as models } from './global-models'
 import _get from 'lodash/get'
 import _omit from 'lodash/omit'
 import { isRef } from '@vue/composition-api'
+import { ServiceState } from '..'
+import { Id } from '@feathersjs/feathers'
 
 const FILTERS = ['$sort', '$limit', '$skip', '$select']
 const OPERATORS = ['$in', '$nin', '$lt', '$lte', '$gt', '$gte', '$ne', '$or']
@@ -114,6 +116,20 @@ export default function makeServiceGetters() {
 
         return Model.copiesById[id]
       }
-    }
+    },
+
+    isCreatePendingById: ({ isIdCreatePending }: ServiceState) => (id: Id) =>
+      isIdCreatePending.includes(id),
+    isUpdatePendingById: ({ isIdUpdatePending }: ServiceState) => (id: Id) =>
+      isIdUpdatePending.includes(id),
+    isPatchPendingById: ({ isIdPatchPending }: ServiceState) => (id: Id) =>
+      isIdPatchPending.includes(id),
+    isRemovePendingById: ({ isIdRemovePending }: ServiceState) => (id: Id) =>
+      isIdRemovePending.includes(id),
+    isPendingById: (state: ServiceState, getters) => (id: Id) =>
+      getters.isCreatePendingById(id) ||
+      getters.isUpdatePendingById(id) ||
+      getters.isPatchPendingById(id) ||
+      getters.isRemovePendingById(id)
   }
 }

--- a/src/service-module/service-module.getters.ts
+++ b/src/service-module/service-module.getters.ts
@@ -133,3 +133,5 @@ export default function makeServiceGetters() {
       getters.isRemovePendingById(id)
   }
 }
+
+export type GetterName = keyof ReturnType<typeof makeServiceGetters>

--- a/src/service-module/service-module.getters.ts
+++ b/src/service-module/service-module.getters.ts
@@ -126,10 +126,12 @@ export default function makeServiceGetters() {
       isIdPatchPending.includes(id),
     isRemovePendingById: ({ isIdRemovePending }: ServiceState) => (id: Id) =>
       isIdRemovePending.includes(id),
-    isPendingById: (state: ServiceState, getters) => (id: Id) =>
+    isSavePendingById: (state: ServiceState, getters) => (id: Id) =>
       getters.isCreatePendingById(id) ||
       getters.isUpdatePendingById(id) ||
-      getters.isPatchPendingById(id) ||
+      getters.isPatchPendingById(id),
+    isPendingById: (state: ServiceState, getters) => (id: Id) =>
+      getters.isSavePendingById(id) ||
       getters.isRemovePendingById(id)
   }
 }

--- a/src/service-module/service-module.mutations.ts
+++ b/src/service-module/service-module.mutations.ts
@@ -403,7 +403,7 @@ export default function makeServiceMutations() {
       const isIdMethodPending = state[`isId${uppercaseMethod}Pending`] as ServiceState['isIdCreatePending']
       // if `id` is an array, ensure it doesn't have duplicates
       const ids = Array.isArray(id) ? [...new Set(id)] : [id]
-      ids.forEach(id => isIdMethodPending.push(id))
+      ids.forEach(id => { if(typeof id === 'number' || typeof id === 'string') isIdMethodPending.push(id) })
     },
     unsetIdPending(state, payload: { method: PendingIdServiceMethodName, id: Id | Id[] }): void {
       const { method, id } = payload

--- a/src/service-module/service-module.mutations.ts
+++ b/src/service-module/service-module.mutations.ts
@@ -19,8 +19,17 @@ import _isObject from 'lodash/isObject'
 import { Id } from '@feathersjs/feathers'
 import { ServiceState } from '..'
 
-type PendingServiceMethodName = 'find' | 'get' | 'create' | 'update' | 'patch' | 'remove'
-type PendingIdServiceMethodName = Exclude<PendingServiceMethodName, 'find' | 'get'>
+export type PendingServiceMethodName =
+  | 'find'
+  | 'get'
+  | 'create'
+  | 'update'
+  | 'patch'
+  | 'remove'
+export type PendingIdServiceMethodName = Exclude<
+  PendingServiceMethodName,
+  'find' | 'get'
+>
 
 export default function makeServiceMutations() {
   function addItems(state, items) {

--- a/src/service-module/service-module.mutations.ts
+++ b/src/service-module/service-module.mutations.ts
@@ -403,7 +403,11 @@ export default function makeServiceMutations() {
       const isIdMethodPending = state[`isId${uppercaseMethod}Pending`] as ServiceState['isIdCreatePending']
       // if `id` is an array, ensure it doesn't have duplicates
       const ids = Array.isArray(id) ? [...new Set(id)] : [id]
-      ids.forEach(id => { if(typeof id === 'number' || typeof id === 'string') isIdMethodPending.push(id) })
+      ids.forEach(id => {
+        if (typeof id === 'number' || typeof id === 'string') {
+          isIdMethodPending.push(id)
+        }
+      })
     },
     unsetIdPending(state, payload: { method: PendingIdServiceMethodName, id: Id | Id[] }): void {
       const { method, id } = payload

--- a/src/service-module/service-module.mutations.ts
+++ b/src/service-module/service-module.mutations.ts
@@ -403,9 +403,9 @@ export default function makeServiceMutations() {
       // if `id` is an array, ensure it doesn't have duplicates
       const ids = Array.isArray(id) ? [...new Set(id)] : [id]
       ids.forEach(id => {
-        const idx = isIdMethodPending.indexOf(id);
+        const idx = isIdMethodPending.indexOf(id)
         if (idx >= 0) {
-          Vue.delete(isIdMethodPending, idx);
+          Vue.delete(isIdMethodPending, idx)
         }
       })
     },

--- a/src/service-module/service-module.state.ts
+++ b/src/service-module/service-module.state.ts
@@ -7,6 +7,7 @@ eslint
 import _omit from 'lodash/omit'
 
 import { MakeServicePluginOptions, Model } from './types'
+import { Id } from '@feathersjs/feathers'
 
 export interface ServiceStateExclusiveDefaults {
   ids: string[]
@@ -36,6 +37,11 @@ export interface ServiceStateExclusiveDefaults {
   }
   paramsForServer: string[]
   modelName?: string
+
+  isIdCreatePending: Id[]
+  isIdUpdatePending: Id[]
+  isIdPatchPending: Id[]
+  isIdRemovePending: Id[]
 }
 
 export interface ServiceState<M extends Model = Model> {
@@ -77,6 +83,10 @@ export interface ServiceState<M extends Model = Model> {
     default?: PaginationState
   }
   modelName?: string
+  isIdCreatePending: Id[]
+  isIdUpdatePending: Id[]
+  isIdPatchPending: Id[]
+  isIdRemovePending: Id[]
 }
 
 export interface PaginationState {
@@ -124,7 +134,12 @@ export default function makeDefaultState(options: MakeServicePluginOptions) {
     errorOnCreate: null,
     errorOnUpdate: null,
     errorOnPatch: null,
-    errorOnRemove: null
+    errorOnRemove: null,
+
+    isIdCreatePending: [],
+    isIdUpdatePending: [],
+    isIdPatchPending: [],
+    isIdRemovePending: [],
   }
 
   if (options.Model) {

--- a/src/service-module/types.ts
+++ b/src/service-module/types.ts
@@ -287,6 +287,28 @@ export interface Model {
    * model is a clone?
    */
   readonly __isClone?: boolean
+
+  /**
+   * `Create` is currently pending on this model
+   */
+  readonly isCreatePending: boolean
+  /**
+   * `Update` is currently pending on this model
+   */
+  readonly isUpdatePending: boolean
+  /**
+   * `Patch` is currently pending on this model
+   */
+  readonly isPatchPending: boolean
+  /**
+   * `Remove` is currently pending on this model
+   */
+  readonly isRemovePending: boolean
+  /**
+   * Any method is currently pending on this model
+   */
+  readonly isPending: boolean
+
   /**
    * Creates a deep copy of the record and stores it on
    * `Model.copiesById`. This allows you to make changes

--- a/src/service-module/types.ts
+++ b/src/service-module/types.ts
@@ -305,6 +305,10 @@ export interface Model {
    */
   readonly isRemovePending: boolean
   /**
+   * Any of `create`, `update` or `patch` is currently pending on this model
+   */
+  readonly isSavePending: boolean
+  /**
    * Any method is currently pending on this model
    */
   readonly isPending: boolean

--- a/test/service-module/make-service-plugin.test.ts
+++ b/test/service-module/make-service-plugin.test.ts
@@ -88,7 +88,11 @@ describe('makeServicePlugin', function() {
       servicePath: 'todos',
       skipRequestIfExists: false,
       tempsById: {},
-      whitelist: []
+      whitelist: [],
+      isIdCreatePending: [],
+      isIdUpdatePending: [],
+      isIdPatchPending: [],
+      isIdRemovePending: [],
     }
 
     assert.deepEqual(_omit(received), _omit(expected), 'defaults in place.')

--- a/test/service-module/model-base.test.ts
+++ b/test/service-module/model-base.test.ts
@@ -113,6 +113,21 @@ describe('makeModel / BaseModel', function () {
         `has ${method} method`
       )
     })
+
+    const getterMethods = [
+      'isCreatePending',
+      'isUpdatePending',
+      'isPatchPending',
+      'isRemovePending',
+      'isPending'
+    ]
+    const m = new BaseModel()
+    getterMethods.forEach(method => {
+      assert(
+        typeof Object.getOwnPropertyDescriptor(Object.getPrototypeOf(m), method).get === 'function',
+        `has ${method} getter`
+      )
+    })
   })
 
   it('allows customization through the FeathersVuexOptions', function () {

--- a/test/service-module/model-base.test.ts
+++ b/test/service-module/model-base.test.ts
@@ -119,6 +119,7 @@ describe('makeModel / BaseModel', function () {
       'isUpdatePending',
       'isPatchPending',
       'isRemovePending',
+      'isSavePending',
       'isPending'
     ]
     const m = new BaseModel()

--- a/test/service-module/model-methods.test.ts
+++ b/test/service-module/model-methods.test.ts
@@ -352,4 +352,113 @@ describe('Models - Methods', function () {
 
     assert(json, 'got json')
   })
+
+  it('Model pending status sets/clears for create/update/patch/remove', async function() {
+    const { makeServicePlugin, BaseModel } = feathersVuex(feathersClient, {
+      idField: '_id',
+      serverAlias: 'model-methods'
+    })
+    class PendingThing extends BaseModel {
+      public static modelName = 'PendingThing'
+      public constructor(data?, options?) {
+        super(data, options)
+      }
+    }
+    const store = new Vuex.Store<RootState>({
+      plugins: [
+        makeServicePlugin({
+          Model: PendingThing,
+          service: feathersClient.service('methods-pending-things')
+        })
+      ]
+    })
+
+    // Create instance
+    const thing = new PendingThing({ description: 'pending test' })
+    const clone = thing.clone()
+    assert(!!thing.__id, "thing has a tempId")
+    assert(clone.__id === thing.__id, "clone has thing's tempId")
+
+    // Manually set the result in a hook to simulate the server request.
+    feathersClient.service('methods-pending-things').hooks({
+      before: {
+        create: [
+          context => {
+            context.result = { _id: 42, ...context.data }
+            // Check pending status
+            assert(thing.isCreatePending === true, 'isCreatePending set')
+            assert(thing.isPending === true, 'isPending set')
+            // Check clone's pending status
+            assert(clone.isCreatePending === true, 'isCreatePending set on clone')
+            assert(clone.isPending === true, 'isPending set on clone')
+            return context
+          }
+        ],
+        update: [
+          context => {
+            context.result = { ...context.data }
+            // Check pending status
+            assert(thing.isUpdatePending === true, 'isUpdatePending set')
+            assert(thing.isPending === true, 'isPending set')
+            // Check clone's pending status
+            assert(clone.isUpdatePending === true, 'isUpdatePending set on clone')
+            assert(clone.isPending === true, 'isPending set on clone')
+            return context
+          }
+        ],
+        patch: [
+          context => {
+            context.result = { ...context.data }
+            // Check pending status
+            assert(thing.isPatchPending === true, 'isPatchPending set')
+            assert(thing.isPending === true, 'isPending set')
+            // Check clone's pending status
+            assert(clone.isPatchPending === true, 'isPatchPending set on clone')
+            assert(clone.isPending === true, 'isPending set on clone')
+            return context
+          }
+        ],
+        remove: [
+          context => {
+            context.result = { ...context.data }
+            // Check pending status
+            assert(thing.isRemovePending === true, 'isRemovePending set')
+            assert(thing.isPending === true, 'isPending set')
+            // Check clone's pending status
+            assert(clone.isRemovePending === true, 'isRemovePending set on clone')
+            assert(clone.isPending === true, 'isPending set on clone')
+            return context
+          }
+        ]
+      }
+    })
+
+    // Create and verify status
+    await thing.create()
+    assert(thing.isCreatePending === false, 'isCreatePending cleared')
+    assert(thing.isPending === false, 'isPending cleared')
+    assert(clone.isCreatePending === false, 'isCreatePending cleared on clone')
+    assert(clone.isPending === false, 'isPending cleared on clone')
+
+    // Update and verify status
+    await thing.update()
+    assert(thing.isUpdatePending === false, 'isUpdatePending cleared')
+    assert(thing.isPending === false, 'isPending cleared')
+    assert(clone.isUpdatePending === false, 'isUpdatePending cleared on clone')
+    assert(clone.isPending === false, 'isPending cleared on clone')
+
+    // Patch and verify status
+    await thing.patch()
+    assert(thing.isPatchPending === false, 'isPatchPending cleared')
+    assert(thing.isPending === false, 'isPending cleared')
+    assert(clone.isPatchPending === false, 'isPatchPending cleared on clone')
+    assert(clone.isPending === false, 'isPending cleared on clone')
+
+    // Remove and verify status
+    await thing.remove()
+    assert(thing.isRemovePending === false, 'isRemovePending cleared')
+    assert(thing.isPending === false, 'isPending cleared')
+    assert(clone.isRemovePending === false, 'isRemovePending cleared on clone')
+    assert(clone.isPending === false, 'isPending cleared on clone')
+  })
 })

--- a/test/service-module/model-methods.test.ts
+++ b/test/service-module/model-methods.test.ts
@@ -387,9 +387,11 @@ describe('Models - Methods', function () {
             context.result = { _id: 42, ...context.data }
             // Check pending status
             assert(thing.isCreatePending === true, 'isCreatePending set')
+            assert(thing.isSavePending === true, 'isSavePending set')
             assert(thing.isPending === true, 'isPending set')
             // Check clone's pending status
             assert(clone.isCreatePending === true, 'isCreatePending set on clone')
+            assert(clone.isSavePending === true, 'isSavePending set on clone')
             assert(clone.isPending === true, 'isPending set on clone')
             return context
           }
@@ -399,9 +401,11 @@ describe('Models - Methods', function () {
             context.result = { ...context.data }
             // Check pending status
             assert(thing.isUpdatePending === true, 'isUpdatePending set')
+            assert(thing.isSavePending === true, 'isSavePending set')
             assert(thing.isPending === true, 'isPending set')
             // Check clone's pending status
             assert(clone.isUpdatePending === true, 'isUpdatePending set on clone')
+            assert(clone.isSavePending === true, 'isSavePending set on clone')
             assert(clone.isPending === true, 'isPending set on clone')
             return context
           }
@@ -411,9 +415,11 @@ describe('Models - Methods', function () {
             context.result = { ...context.data }
             // Check pending status
             assert(thing.isPatchPending === true, 'isPatchPending set')
+            assert(thing.isSavePending === true, 'isSavePending set')
             assert(thing.isPending === true, 'isPending set')
             // Check clone's pending status
             assert(clone.isPatchPending === true, 'isPatchPending set on clone')
+            assert(clone.isSavePending === true, 'isSavePending set on clone')
             assert(clone.isPending === true, 'isPending set on clone')
             return context
           }
@@ -423,9 +429,11 @@ describe('Models - Methods', function () {
             context.result = { ...context.data }
             // Check pending status
             assert(thing.isRemovePending === true, 'isRemovePending set')
+            assert(thing.isSavePending === false, 'isSavePending clear on remove')
             assert(thing.isPending === true, 'isPending set')
             // Check clone's pending status
             assert(clone.isRemovePending === true, 'isRemovePending set on clone')
+            assert(clone.isSavePending === false, 'isSavePending clear on remove on clone')
             assert(clone.isPending === true, 'isPending set on clone')
             return context
           }
@@ -436,29 +444,37 @@ describe('Models - Methods', function () {
     // Create and verify status
     await thing.create()
     assert(thing.isCreatePending === false, 'isCreatePending cleared')
+    assert(thing.isSavePending === false, 'isSavePending cleared')
     assert(thing.isPending === false, 'isPending cleared')
     assert(clone.isCreatePending === false, 'isCreatePending cleared on clone')
+    assert(clone.isSavePending === false, 'isSavePending cleared on clone')
     assert(clone.isPending === false, 'isPending cleared on clone')
 
     // Update and verify status
     await thing.update()
     assert(thing.isUpdatePending === false, 'isUpdatePending cleared')
+    assert(thing.isSavePending === false, 'isSavePending cleared')
     assert(thing.isPending === false, 'isPending cleared')
     assert(clone.isUpdatePending === false, 'isUpdatePending cleared on clone')
+    assert(clone.isSavePending === false, 'isSavePending cleared on clone')
     assert(clone.isPending === false, 'isPending cleared on clone')
 
     // Patch and verify status
     await thing.patch()
     assert(thing.isPatchPending === false, 'isPatchPending cleared')
+    assert(thing.isSavePending === false, 'isSavePending cleared')
     assert(thing.isPending === false, 'isPending cleared')
     assert(clone.isPatchPending === false, 'isPatchPending cleared on clone')
+    assert(clone.isSavePending === false, 'isSavePending cleared on clone')
     assert(clone.isPending === false, 'isPending cleared on clone')
 
     // Remove and verify status
     await thing.remove()
     assert(thing.isRemovePending === false, 'isRemovePending cleared')
+    assert(thing.isSavePending === false, 'isSavePending cleared')
     assert(thing.isPending === false, 'isPending cleared')
     assert(clone.isRemovePending === false, 'isRemovePending cleared on clone')
+    assert(clone.isSavePending === false, 'isSavePending cleared on clone')
     assert(clone.isPending === false, 'isPending cleared on clone')
   })
 })

--- a/test/service-module/model-temp-ids.test.ts
+++ b/test/service-module/model-temp-ids.test.ts
@@ -612,9 +612,11 @@ describe('Models - Temp Ids', function() {
             context.result = { _id: 42, ...context.data }
             // Check pending status
             assert(thing.isCreatePending === true, 'isCreatePending set')
+            assert(thing.isSavePending === true, 'isSavePending set')
             assert(thing.isPending === true, 'isPending set')
             // Check clone's pending status
             assert(clone.isCreatePending === true, 'isCreatePending set')
+            assert(clone.isSavePending === true, 'isSavePending set on clone')
             assert(clone.isPending === true, 'isPending set')
             return context
           }
@@ -625,8 +627,10 @@ describe('Models - Temp Ids', function() {
     // Save and verify status
     await thing.save()
     assert(thing.isCreatePending === false, 'isCreatePending cleared')
+    assert(thing.isSavePending === false, 'isSavePending cleared')
     assert(thing.isPending === false, 'isPending cleared')
     assert(clone.isCreatePending === false, 'isCreatePending cleared')
+    assert(clone.isSavePending === false, 'isSavePending cleared on clone')
     assert(clone.isPending === false, 'isPending cleared')
   })
 })

--- a/test/service-module/module.getters.test.ts
+++ b/test/service-module/module.getters.test.ts
@@ -21,7 +21,7 @@ const options = {
   service: null
 }
 
-const { find, count, list, get, getCopyById, isCreatePendingById, isUpdatePendingById, isPatchPendingById, isRemovePendingById, isPendingById } = makeServiceGetters()
+const { find, count, list, get, getCopyById, isCreatePendingById, isUpdatePendingById, isPatchPendingById, isRemovePendingById, isSavePendingById, isPendingById } = makeServiceGetters()
 const { addItems, setIdPending, unsetIdPending } = makeServiceMutations()
 
 describe('Service Module - Getters', function () {
@@ -406,60 +406,80 @@ describe('Service Module - Getters', function () {
 
   it('is*PendingById', function() {
     const { state } = this
-    const getters = { isCreatePendingById, isUpdatePendingById, isPatchPendingById, isRemovePendingById }
+
+    // Set up getters
+    const getters: any = {
+      isCreatePendingById: isCreatePendingById(state),
+      isUpdatePendingById: isUpdatePendingById(state),
+      isPatchPendingById: isPatchPendingById(state),
+      isRemovePendingById: isRemovePendingById(state),
+      isSavePendingById,
+      isPendingById
+    }
+    getters.isSavePendingById = isSavePendingById(state, getters)
+    getters.isPendingById = isPendingById(state, getters)
 
     assert(isCreatePendingById(state)(42) === false, 'creating status is clear')
     assert(isUpdatePendingById(state)(42) === false, 'updating status is clear')
     assert(isPatchPendingById(state)(42) === false, 'patching status is clear')
     assert(isRemovePendingById(state)(42) === false, 'removing status is clear')
-    assert(isPendingById(state, getters)(42), 'any method pending status is clear')
+    assert(isSavePendingById(state, getters)(42) === false, 'saving status is clear')
+    assert(isPendingById(state, getters)(42) === false, 'any method pending status is clear')
 
     // Create
     setIdPending(state, { method: 'create', id: 42})
     assert(isCreatePendingById(state)(42) === true, 'creating status is set')
-    assert(isPendingById(state, getters)(42), 'any method pending status is set')
+    assert(isSavePendingById(state, getters)(42) === true, 'saving status is set')
+    assert(isPendingById(state, getters)(42) === true, 'any method pending status is set')
 
     unsetIdPending(state, { method: 'create', id: 42 })
     assert(isCreatePendingById(state)(42) === false, 'creating status is clear')
     assert(isUpdatePendingById(state)(42) === false, 'updating status is clear')
     assert(isPatchPendingById(state)(42) === false, 'patching status is clear')
     assert(isRemovePendingById(state)(42) === false, 'removing status is clear')
-    assert(isPendingById(state, getters)(42), 'any method pending status is clear')
+    assert(isSavePendingById(state, getters)(42) === false, 'saving status is clear')
+    assert(isPendingById(state, getters)(42) === false, 'any method pending status is clear')
 
     // Update
     setIdPending(state, { method: 'update', id: 42})
     assert(isUpdatePendingById(state)(42) === true, 'updating status is set')
-    assert(isPendingById(state, getters)(42), 'any method pending status is set')
+    assert(isSavePendingById(state, getters)(42) === true, 'saving status is set')
+    assert(isPendingById(state, getters)(42) === true, 'any method pending status is set')
 
     unsetIdPending(state, { method: 'update', id: 42 })
     assert(isCreatePendingById(state)(42) === false, 'creating status is clear')
     assert(isUpdatePendingById(state)(42) === false, 'updating status is clear')
     assert(isPatchPendingById(state)(42) === false, 'patching status is clear')
     assert(isRemovePendingById(state)(42) === false, 'removing status is clear')
-    assert(isPendingById(state, getters)(42), 'any method pending status is clear')
+    assert(isSavePendingById(state, getters)(42) === false, 'saving status is clear')
+    assert(isPendingById(state, getters)(42) === false, 'any method pending status is clear')
 
     // Patch
     setIdPending(state, { method: 'patch', id: 42})
     assert(isPatchPendingById(state)(42) === true, 'patching status is set')
-    assert(isPendingById(state, getters)(42), 'any method pending status is set')
+    assert(isSavePendingById(state, getters)(42) === true, 'saving status is set')
+    assert(isPendingById(state, getters)(42) === true, 'any method pending status is set')
 
     unsetIdPending(state, { method: 'patch', id: 42 })
     assert(isCreatePendingById(state)(42) === false, 'creating status is clear')
     assert(isUpdatePendingById(state)(42) === false, 'updating status is clear')
     assert(isPatchPendingById(state)(42) === false, 'patching status is clear')
     assert(isRemovePendingById(state)(42) === false, 'removing status is clear')
-    assert(isPendingById(state, getters)(42), 'any method pending status is clear')
+    assert(isSavePendingById(state, getters)(42) === false, 'saving status is clear')
+    assert(isPendingById(state, getters)(42) === false, 'any method pending status is clear')
 
     // Remove
     setIdPending(state, { method: 'remove', id: 42})
     assert(isRemovePendingById(state)(42) === true, 'removing status is set')
-    assert(isPendingById(state, getters)(42), 'any method pending status is set')
+    assert(isSavePendingById(state, getters)(42) === false, 'saving status is clear for remove')
+    assert(isPendingById(state, getters)(42) === true, 'any method pending status is set')
 
     unsetIdPending(state, { method: 'remove', id: 42 })
     assert(isCreatePendingById(state)(42) === false, 'creating status is clear')
     assert(isUpdatePendingById(state)(42) === false, 'updating status is clear')
     assert(isPatchPendingById(state)(42) === false, 'patching status is clear')
     assert(isRemovePendingById(state)(42) === false, 'removing status is clear')
-    assert(isPendingById(state, getters)(42), 'any method pending status is clear')
+    assert(isSavePendingById(state, getters)(42) === false, 'saving status is clear')
+    assert(isPendingById(state, getters)(42) === false, 'any method pending status is clear')
   })
 })

--- a/test/service-module/module.getters.test.ts
+++ b/test/service-module/module.getters.test.ts
@@ -21,8 +21,8 @@ const options = {
   service: null
 }
 
-const { find, count, list, get, getCopyById } = makeServiceGetters()
-const { addItems } = makeServiceMutations()
+const { find, count, list, get, getCopyById, isCreatePendingById, isUpdatePendingById, isPatchPendingById, isRemovePendingById, isPendingById } = makeServiceGetters()
+const { addItems, setIdPending, unsetIdPending } = makeServiceMutations()
 
 describe('Service Module - Getters', function () {
   beforeEach(function () {
@@ -402,5 +402,64 @@ describe('Service Module - Getters', function () {
 
     const total = count(state, { find })({ query: {} })
     assert(total === 3, 'count is 3')
+  })
+
+  it('is*PendingById', function() {
+    const { state } = this
+    const getters = { isCreatePendingById, isUpdatePendingById, isPatchPendingById, isRemovePendingById }
+
+    assert(isCreatePendingById(state)(42) === false, 'creating status is clear')
+    assert(isUpdatePendingById(state)(42) === false, 'updating status is clear')
+    assert(isPatchPendingById(state)(42) === false, 'patching status is clear')
+    assert(isRemovePendingById(state)(42) === false, 'removing status is clear')
+    assert(isPendingById(state, getters)(42), 'any method pending status is clear')
+
+    // Create
+    setIdPending(state, { method: 'create', id: 42})
+    assert(isCreatePendingById(state)(42) === true, 'creating status is set')
+    assert(isPendingById(state, getters)(42), 'any method pending status is set')
+
+    unsetIdPending(state, { method: 'create', id: 42 })
+    assert(isCreatePendingById(state)(42) === false, 'creating status is clear')
+    assert(isUpdatePendingById(state)(42) === false, 'updating status is clear')
+    assert(isPatchPendingById(state)(42) === false, 'patching status is clear')
+    assert(isRemovePendingById(state)(42) === false, 'removing status is clear')
+    assert(isPendingById(state, getters)(42), 'any method pending status is clear')
+
+    // Update
+    setIdPending(state, { method: 'update', id: 42})
+    assert(isUpdatePendingById(state)(42) === true, 'updating status is set')
+    assert(isPendingById(state, getters)(42), 'any method pending status is set')
+
+    unsetIdPending(state, { method: 'update', id: 42 })
+    assert(isCreatePendingById(state)(42) === false, 'creating status is clear')
+    assert(isUpdatePendingById(state)(42) === false, 'updating status is clear')
+    assert(isPatchPendingById(state)(42) === false, 'patching status is clear')
+    assert(isRemovePendingById(state)(42) === false, 'removing status is clear')
+    assert(isPendingById(state, getters)(42), 'any method pending status is clear')
+
+    // Patch
+    setIdPending(state, { method: 'patch', id: 42})
+    assert(isPatchPendingById(state)(42) === true, 'patching status is set')
+    assert(isPendingById(state, getters)(42), 'any method pending status is set')
+
+    unsetIdPending(state, { method: 'patch', id: 42 })
+    assert(isCreatePendingById(state)(42) === false, 'creating status is clear')
+    assert(isUpdatePendingById(state)(42) === false, 'updating status is clear')
+    assert(isPatchPendingById(state)(42) === false, 'patching status is clear')
+    assert(isRemovePendingById(state)(42) === false, 'removing status is clear')
+    assert(isPendingById(state, getters)(42), 'any method pending status is clear')
+
+    // Remove
+    setIdPending(state, { method: 'remove', id: 42})
+    assert(isRemovePendingById(state)(42) === true, 'removing status is set')
+    assert(isPendingById(state, getters)(42), 'any method pending status is set')
+
+    unsetIdPending(state, { method: 'remove', id: 42 })
+    assert(isCreatePendingById(state)(42) === false, 'creating status is clear')
+    assert(isUpdatePendingById(state)(42) === false, 'updating status is clear')
+    assert(isPatchPendingById(state)(42) === false, 'patching status is clear')
+    assert(isRemovePendingById(state)(42) === false, 'removing status is clear')
+    assert(isPendingById(state, getters)(42), 'any method pending status is clear')
   })
 })

--- a/test/service-module/service-module.actions.test.ts
+++ b/test/service-module/service-module.actions.test.ts
@@ -929,6 +929,7 @@ describe('Service Module - Actions', () => {
               assert(todoState.errorOnUpdate === null)
               assert(todoState.isUpdatePending === false)
               assert(store.getters['my-todos/isUpdatePendingById'](0) === false, 'ID pending update clear')
+              assert(store.getters['my-todos/isSavePendingById'](0) === false, 'ID pending save clear')
               assert(store.getters['my-todos/isPendingById'](0) === false, 'ID pending clear')
               assert.deepEqual(
                 todoState.keyedById[responseFromUpdate.id],
@@ -942,6 +943,7 @@ describe('Service Module - Actions', () => {
           assert(todoState.errorOnUpdate === null)
           assert(todoState.isUpdatePending === true)
           assert(store.getters['my-todos/isUpdatePendingById'](0) === true, 'ID pending update set')
+          assert(store.getters['my-todos/isSavePendingById'](0) === true, 'ID pending save set')
           assert(store.getters['my-todos/isPendingById'](0) === true, 'ID pending set')
           assert(todoState.idField === 'id')
         })
@@ -1027,6 +1029,7 @@ describe('Service Module - Actions', () => {
               assert(todoState.errorOnPatch === null)
               assert(todoState.isPatchPending === false)
               assert(store.getters['my-todos/isPatchPendingById'](0) === false, 'ID pending patch clear')
+              assert(store.getters['my-todos/isSavePendingById'](0) === false, 'ID pending save clear')
               assert(store.getters['my-todos/isPendingById'](0) === false, 'ID pending clear')
               assert.deepEqual(
                 todoState.keyedById[responseFromPatch.id],
@@ -1040,6 +1043,7 @@ describe('Service Module - Actions', () => {
           assert(todoState.errorOnPatch === null)
           assert(todoState.isPatchPending === true)
           assert(store.getters['my-todos/isPatchPendingById'](0) === true, 'ID pending patch set')
+          assert(store.getters['my-todos/isSavePendingById'](0) === true, 'ID pending save set')
           assert(store.getters['my-todos/isPendingById'](0) === true, 'ID pending set')
           assert(todoState.idField === 'id')
         })
@@ -1107,6 +1111,7 @@ describe('Service Module - Actions', () => {
               assert(todoState.errorOnPatch === null)
               assert(todoState.isPatchPending === false)
               assert(store.getters['my-todos/isPatchPendingById'](0) === false, 'ID pending patch clear')
+              assert(store.getters['my-todos/isSavePendingById'](0) === false, 'ID pending save clear')
               assert(store.getters['my-todos/isPendingById'](0) === false, 'ID pending clear')
               assert.deepEqual(
                 todoState.keyedById[responseFromPatch.id],
@@ -1120,6 +1125,7 @@ describe('Service Module - Actions', () => {
           assert(todoState.errorOnPatch === null)
           assert(todoState.isPatchPending === true)
           assert(store.getters['my-todos/isPatchPendingById'](0) === true, 'ID pending patch set')
+          assert(store.getters['my-todos/isSavePendingById'](0) === true, 'ID pending save set')
           assert(store.getters['my-todos/isPendingById'](0) === true, 'ID pending set')
           assert(todoState.idField === 'id')
         })
@@ -1187,6 +1193,7 @@ describe('Service Module - Actions', () => {
               assert(todoState.errorOnRemove === null)
               assert(todoState.isRemovePending === false)
               assert(store.getters['my-todos/isRemovePendingById'](0) === false, 'ID pending remove clear')
+              assert(store.getters['my-todos/isSavePendingById'](0) === false, 'ID pending save clear')
               assert(store.getters['my-todos/isPendingById'](0) === false, 'ID pending clear')
               assert.deepEqual(todoState.keyedById, {})
               done()
@@ -1201,6 +1208,7 @@ describe('Service Module - Actions', () => {
           assert(todoState.errorOnRemove === null)
           assert(todoState.isRemovePending === true)
           assert(store.getters['my-todos/isRemovePendingById'](0) === true, 'ID pending remove set')
+          assert(store.getters['my-todos/isSavePendingById'](0) === false, 'ID pending save clear')
           assert(store.getters['my-todos/isPendingById'](0) === true, 'ID pending set')
           assert(todoState.idField === 'id')
         })

--- a/test/service-module/service-module.actions.test.ts
+++ b/test/service-module/service-module.actions.test.ts
@@ -928,6 +928,8 @@ describe('Service Module - Actions', () => {
               assert(todoState.ids.length === 1)
               assert(todoState.errorOnUpdate === null)
               assert(todoState.isUpdatePending === false)
+              assert(store.getters['my-todos/isUpdatePendingById'](0) === false, 'ID pending update clear')
+              assert(store.getters['my-todos/isPendingById'](0) === false, 'ID pending clear')
               assert.deepEqual(
                 todoState.keyedById[responseFromUpdate.id],
                 responseFromUpdate
@@ -939,6 +941,8 @@ describe('Service Module - Actions', () => {
           assert(todoState.ids.length === 1)
           assert(todoState.errorOnUpdate === null)
           assert(todoState.isUpdatePending === true)
+          assert(store.getters['my-todos/isUpdatePendingById'](0) === true, 'ID pending update set')
+          assert(store.getters['my-todos/isPendingById'](0) === true, 'ID pending set')
           assert(todoState.idField === 'id')
         })
         .catch(error => {
@@ -1022,6 +1026,8 @@ describe('Service Module - Actions', () => {
               assert(todoState.ids.length === 1)
               assert(todoState.errorOnPatch === null)
               assert(todoState.isPatchPending === false)
+              assert(store.getters['my-todos/isPatchPendingById'](0) === false, 'ID pending patch clear')
+              assert(store.getters['my-todos/isPendingById'](0) === false, 'ID pending clear')
               assert.deepEqual(
                 todoState.keyedById[responseFromPatch.id],
                 responseFromPatch
@@ -1033,6 +1039,8 @@ describe('Service Module - Actions', () => {
           assert(todoState.ids.length === 1)
           assert(todoState.errorOnPatch === null)
           assert(todoState.isPatchPending === true)
+          assert(store.getters['my-todos/isPatchPendingById'](0) === true, 'ID pending patch set')
+          assert(store.getters['my-todos/isPendingById'](0) === true, 'ID pending set')
           assert(todoState.idField === 'id')
         })
     })
@@ -1098,6 +1106,8 @@ describe('Service Module - Actions', () => {
               assert(todoState.ids.length === 1)
               assert(todoState.errorOnPatch === null)
               assert(todoState.isPatchPending === false)
+              assert(store.getters['my-todos/isPatchPendingById'](0) === false, 'ID pending patch clear')
+              assert(store.getters['my-todos/isPendingById'](0) === false, 'ID pending clear')
               assert.deepEqual(
                 todoState.keyedById[responseFromPatch.id],
                 responseFromPatch
@@ -1109,6 +1119,8 @@ describe('Service Module - Actions', () => {
           assert(todoState.ids.length === 1)
           assert(todoState.errorOnPatch === null)
           assert(todoState.isPatchPending === true)
+          assert(store.getters['my-todos/isPatchPendingById'](0) === true, 'ID pending patch set')
+          assert(store.getters['my-todos/isPendingById'](0) === true, 'ID pending set')
           assert(todoState.idField === 'id')
         })
     })
@@ -1174,6 +1186,8 @@ describe('Service Module - Actions', () => {
               assert(todoState.ids.length === 0)
               assert(todoState.errorOnRemove === null)
               assert(todoState.isRemovePending === false)
+              assert(store.getters['my-todos/isRemovePendingById'](0) === false, 'ID pending remove clear')
+              assert(store.getters['my-todos/isPendingById'](0) === false, 'ID pending clear')
               assert.deepEqual(todoState.keyedById, {})
               done()
             })
@@ -1186,6 +1200,8 @@ describe('Service Module - Actions', () => {
           assert(todoState.ids.length === 1)
           assert(todoState.errorOnRemove === null)
           assert(todoState.isRemovePending === true)
+          assert(store.getters['my-todos/isRemovePendingById'](0) === true, 'ID pending remove set')
+          assert(store.getters['my-todos/isPendingById'](0) === true, 'ID pending set')
           assert(todoState.idField === 'id')
         })
     })

--- a/test/service-module/service-module.mutations.test.ts
+++ b/test/service-module/service-module.mutations.test.ts
@@ -1166,7 +1166,7 @@ describe('Service Module - Mutations', function() {
 
         // Unset pending & check
         unsetPending(state, method)
-        assert(!state[`!is${uppercaseMethod}Pending`])
+        assert(!state[`is${uppercaseMethod}Pending`])
       })
     })
   })

--- a/test/service-module/service-module.mutations.test.ts
+++ b/test/service-module/service-module.mutations.test.ts
@@ -6,7 +6,7 @@ eslint
 import { assert } from 'chai'
 import { assertGetter } from '../test-utils'
 import makeServiceMutations, {
-  PendingServiceMethodName
+  PendingServiceMethodName, PendingIdServiceMethodName
 } from '../../src/service-module/service-module.mutations'
 import makeServiceState from '../../src/service-module/service-module.state'
 import errors from '@feathersjs/errors'
@@ -55,7 +55,9 @@ const {
   setPending,
   unsetPending,
   setError,
-  clearError
+  clearError,
+  setIdPending,
+  unsetIdPending
 } = makeServiceMutations()
 
 describe('Service Module - Mutations', function() {
@@ -1165,6 +1167,31 @@ describe('Service Module - Mutations', function() {
         // Unset pending & check
         unsetPending(state, method)
         assert(!state[`!is${uppercaseMethod}Pending`])
+      })
+    })
+  })
+
+  describe('Per-instance Pending', function() {
+    it('setIdPending && unsetIdPending', function() {
+      const state = this.state
+      const methods: PendingIdServiceMethodName[] = [
+        'create',
+        'update',
+        'patch',
+        'remove'
+      ]
+
+      methods.forEach(method => {
+        const uppercaseMethod = method.charAt(0).toUpperCase() + method.slice(1)
+        assert(state[`isId${uppercaseMethod}Pending`].length === 0)
+
+        // Set pending & check
+        setIdPending(state, { method, id: 42 })
+        assert(state[`isId${uppercaseMethod}Pending`].includes(42))
+
+        // Unset pending & check
+        unsetIdPending(state, { method, id: 42 })
+        assert(state[`isId${uppercaseMethod}Pending`].length === 0)
       })
     })
   })

--- a/test/service-module/service-module.mutations.test.ts
+++ b/test/service-module/service-module.mutations.test.ts
@@ -5,7 +5,9 @@ eslint
 */
 import { assert } from 'chai'
 import { assertGetter } from '../test-utils'
-import makeServiceMutations from '../../src/service-module/service-module.mutations'
+import makeServiceMutations, {
+  PendingServiceMethodName
+} from '../../src/service-module/service-module.mutations'
 import makeServiceState from '../../src/service-module/service-module.state'
 import errors from '@feathersjs/errors'
 import Vue from 'vue'
@@ -1143,7 +1145,14 @@ describe('Service Module - Mutations', function() {
   describe('Pending', function() {
     it('setPending && unsetPending', function() {
       const state = this.state
-      const methods = ['find', 'get', 'create', 'update', 'patch', 'remove']
+      const methods: PendingServiceMethodName[] = [
+        'find',
+        'get',
+        'create',
+        'update',
+        'patch',
+        'remove'
+      ]
 
       methods.forEach(method => {
         const uppercaseMethod = method.charAt(0).toUpperCase() + method.slice(1)
@@ -1163,7 +1172,14 @@ describe('Service Module - Mutations', function() {
   describe('Errors', function() {
     it('setError', function() {
       const state = this.state
-      const methods = ['find', 'get', 'create', 'update', 'patch', 'remove']
+      const methods: PendingServiceMethodName[] = [
+        'find',
+        'get',
+        'create',
+        'update',
+        'patch',
+        'remove'
+      ]
 
       methods.forEach(method => {
         const uppercaseMethod = method.charAt(0).toUpperCase() + method.slice(1)
@@ -1176,7 +1192,14 @@ describe('Service Module - Mutations', function() {
 
     it('setError with feathers-errors', function() {
       const state = this.state
-      const methods = ['find', 'get', 'create', 'update', 'patch', 'remove']
+      const methods: PendingServiceMethodName[] = [
+        'find',
+        'get',
+        'create',
+        'update',
+        'patch',
+        'remove'
+      ]
 
       methods.forEach(method => {
         const uppercaseMethod = method.charAt(0).toUpperCase() + method.slice(1)
@@ -1196,7 +1219,14 @@ describe('Service Module - Mutations', function() {
 
     it('clearError', function() {
       const state = this.state
-      const methods = ['find', 'get', 'create', 'update', 'patch', 'remove']
+      const methods: PendingServiceMethodName[] = [
+        'find',
+        'get',
+        'create',
+        'update',
+        'patch',
+        'remove'
+      ]
 
       methods.forEach(method => {
         const uppercaseMethod = method.charAt(0).toUpperCase() + method.slice(1)

--- a/test/service-module/service-module.reinitialization.test.ts
+++ b/test/service-module/service-module.reinitialization.test.ts
@@ -89,7 +89,11 @@ describe('Service Module - Reinitialization', function() {
       servicePath: 'todos',
       skipRequestIfExists: false,
       tempsById: {},
-      whitelist: []
+      whitelist: [],
+      isIdCreatePending: [],
+      isIdUpdatePending: [],
+      isIdPatchPending: [],
+      isIdRemovePending: [],
     }
 
     assert.deepEqual(

--- a/test/service-module/service-module.test.ts
+++ b/test/service-module/service-module.test.ts
@@ -663,7 +663,11 @@ describe('Service Module', function() {
           defaultSkip: null
         },
         paramsForServer: ['$populateParams'],
-        whitelist: []
+        whitelist: [],
+        isIdCreatePending: [],
+        isIdUpdatePending: [],
+        isIdPatchPending: [],
+        isIdRemovePending: [],
       }
 
       assert.deepEqual(


### PR DESCRIPTION
### Summary

Adds per-instance, per-method pending status to FeathersVuex per discussion in #518 

PR includes new state, new getters, new mutations, new `BaseModel` `get`ers, and modifies the actions for `create`, `update`, `patch` and `remove` to call the new mutations.

### What Problem am I Solving?

Currently, FeathersVuex tracks `pending` status for `create`, `update`, `patch` and `remove` per service... but only in an all-or-nothing way. This means that if any model is pending, the status for that service is set. As expressed in #518, it can be useful to have a status for *this* model is patching and *that* model is removing, or similar.

In my opinion, the most useful new thing in this PR is that the `BaseModel` now has the following `get`ers:
- `isCreatePending`
- `isUpdatePending`
- `isPatchPending`
- `isRemovePending`
- `isPending` - `true` if any of the previous four statuses are `true`

### Implementation

I decided to use `Array`s of `id`s in the Vuex state for maintaining the pending status. I chose to use `Array`s instead of `Object`s because for each `id`, if a method is called multiple times, an Array can track that there are multiple requests in progress and therefore the status will not clear until the last request finishes.

I decided to make the status part of the Vuex state instead of part of the Model class to keep the status in-sync between clones and originals. E.g. when a clone is modified and `patch`ed, the original model's status indicates that a `patch` is in progress.

:heart:

*Marking this as WIP because I want to add docs and tests*