### PR TITLE
Update make-find-mixin.ts

### DIFF
--- a/src/make-find-mixin.ts
+++ b/src/make-find-mixin.ts
@@ -18,7 +18,7 @@ export default function makeFindMixin(options) {
   const {
     service,
     params,
-    fetchQuery,
+    fetchParams,
     queryWhen = () => true,
     local = false,
     qid = 'default',
@@ -319,7 +319,7 @@ export default function makeFindMixin(options) {
 
   setupAttribute(SERVICE_NAME, service, 'computed', true)
   setupAttribute(PARAMS, params)
-  setupAttribute(FETCH_PARAMS, fetchQuery)
+  setupAttribute(FETCH_PARAMS, fetchParams)
   setupAttribute(QUERY_WHEN, queryWhen, 'computed')
   setupAttribute(LOCAL, local)
 


### PR DESCRIPTION
The `fetchParams` attribute was not supported, but the `fetchQuery` was. From time to time I like to use the `params` and `fetchParams` directly in the `makeFindMixin` options. `fetchParams` does nothing here, renaming it to `fetchQuery` directly works, but as a params-object.

Strictly speaking, this would be a breaking change, if anyone used it this way before. I can't imagine that's the case, so IMO it's a fix to be compliant with the docs