### PR TITLE
support copies in find-getter and other things

### DIFF
--- a/docs/composition-api.md
+++ b/docs/composition-api.md
@@ -119,6 +119,7 @@ And here's a look at each individual property:
   - Set `params.paginate` to `true` to turn off realtime updates for the results and defer pagination to the API server.  Pagination works the same as for the [makeFindMixin pagination](./mixins.html#pagination-with-fall-through-cacheing).
   - Set `params.debounce` to an integer and the API requests will automatically be debounced by that many milliseconds.  For example, setting `debounce: 1000` will assure that the API request will be made at most every 1 second.
   - Set `params.temps` to `true` to include temporary (local-only) items in the results. Temporary records are instances that have been created but not yet saved to the database.
+  - Set `params.copies` to `true` to include cloned items in the results. The queried items get replaced with the corresponding copies from `copiesById`
 - `fetchParams` This is a separate set of params that, when provided, will become the params sent to the API server.  The `params` will then only be used to query data from the local data store.
   - Explicitly returning `null` will prevent an API request from being made.
 - `queryWhen` must be a `computed` property which returns a `boolean`. It provides a logical separation for preventing API requests *outside* of the `params`.

--- a/docs/service-plugin.md
+++ b/docs/service-plugin.md
@@ -199,7 +199,10 @@ Service modules include the following getters:
 
 - `list {Array}` - an array of items. The array form of `keyedById`  Read only.
 - `find(params) {Function}` - a helper function that allows you to use the [Feathers Adapter Common API](https://docs.feathersjs.com/api/databases/common) and [Query API](https://docs.feathersjs.com/api/databases/querying) to pull data from the store.  This allows you to treat the store just like a local Feathers database adapter (but without hooks).
-  - `params {Object}` - an object with a `query` object and optional `paginate` and `temps` boolean properties. The `query` is in the FeathersJS query format. You can set `params.paginate` to `false` to disable pagination for a single request.
+  - `params {Object}` - an object with a `query` object and optional properties. You can set the following  properties:
+    - `params.query {Boolean}` - The `query` is in the FeathersJS query format.
+    - `params.temps {Boolean}` - **Default:** `false` - if `true` also consider temporary records from `tempsById`
+    - `params.copies {Boolean}` - **Default:** `false` - if `true`: first search for the regular records and then replace the records with the related copies from `copiesById`
 - `count(params) {Function}` - a helper function that counts items in the store matching the provided query in the params and returns this number <Badge text="3.12.0+" />
   - `params {Object}` - an object with a `query` object and an optional `temps` boolean property.
 - `get(id[, params]) {Function}` - a function that allows you to query the store for a single item, by id.  It works the same way as `get` requests in Feathers database adapters.

--- a/src/service-module/make-base-model.ts
+++ b/src/service-module/make-base-model.ts
@@ -79,7 +79,8 @@ export default function makeBaseModel(options: FeathersVuexOptions) {
     public static serverAlias: string = options.serverAlias
 
     public static readonly models = globalModels as GlobalModels // Can access other Models here
-    public static copiesById: {
+
+    public static readonly copiesById: {
       [key: string]: Model | undefined
       [key: number]: Model | undefined
     } = {}
@@ -365,7 +366,9 @@ export default function makeBaseModel(options: FeathersVuexOptions) {
      * Calls service patch with the current instance data
      * @param params
      */
-    public patch<D extends {} = AnyData>(params?: PatchParams<D>): Promise<this> {
+    public patch<D extends {} = AnyData>(
+      params?: PatchParams<D>
+    ): Promise<this> {
       const { idField, _dispatch } = this.constructor as typeof BaseModel
       const id = getId(this, idField)
 
@@ -410,7 +413,9 @@ export default function makeBaseModel(options: FeathersVuexOptions) {
         }
         return _dispatch.call(this.constructor, 'remove', [id, params])
       } else {
+        // is temp
         _commit.call(this.constructor, 'removeTemps', [this[tempIdField]])
+        _commit.call(this.constructor, 'clearCopy', [this[tempIdField]])
         return Promise.resolve(this)
       }
     }

--- a/src/service-module/service-module.getters.ts
+++ b/src/service-module/service-module.getters.ts
@@ -25,7 +25,7 @@ const getCopiesById = ({
   if (keepCopiesInStore) {
     return copiesById
   } else {
-    const Model = _get(models, `[${serverAlias}].byServicePath[${servicePath}]`)
+    const Model = _get(models, [serverAlias, 'byServicePath', servicePath])
 
     return Model.copiesById
   }

--- a/src/service-module/service-module.getters.ts
+++ b/src/service-module/service-module.getters.ts
@@ -57,7 +57,7 @@ export default function makeServiceGetters() {
       let values = _.values(keyedById)
 
       if (params.temps) {
-        values = values.concat(_.values(state.tempsById))
+        values.push(..._.values(state.tempsById))
       }
 
       values = values.filter(sift(query))

--- a/src/service-module/service-module.mutations.ts
+++ b/src/service-module/service-module.mutations.ts
@@ -173,9 +173,17 @@ export default function makeServiceMutations() {
       const isIdOk = idToBeRemoved !== null && idToBeRemoved !== undefined
       const index = state.ids.findIndex(i => i === idToBeRemoved)
 
+      const Model = _get(models, `[${state.serverAlias}][${state.modelName}]`)
+      const copiesById = state.keepCopiesInStore
+        ? state.copiesById
+        : Model.copiesById
+
       if (isIdOk && index !== null && index !== undefined) {
         Vue.delete(state.ids, index)
         Vue.delete(state.keyedById, idToBeRemoved)
+        if (copiesById.hasOwnProperty(idToBeRemoved)) {
+          Vue.delete(copiesById, idToBeRemoved)
+        }
       }
     },
 
@@ -211,8 +219,17 @@ export default function makeServiceMutations() {
         map[id] = true
         return map
       }, {})
+
+      const Model = _get(models, `[${state.serverAlias}][${state.modelName}]`)
+      const copiesById = state.keepCopiesInStore
+        ? state.copiesById
+        : Model.copiesById
+
       idsToRemove.forEach(id => {
         Vue.delete(state.keyedById, id)
+        if (copiesById.hasOwnProperty(id)) {
+          Vue.delete(copiesById, id)
+        }
       })
 
       // Get indexes to remove from the ids array.
@@ -242,6 +259,18 @@ export default function makeServiceMutations() {
     clearAll(state) {
       state.ids = []
       state.keyedById = {}
+
+      if (state.keepCopiesInStore) {
+        state.copiesById = {}
+      } else {
+        const Model = _get(
+          models,
+          `[${state.serverAlias}].byServicePath[${state.servicePath}]`
+        )
+        Object.keys(Model.copiesById).forEach(k =>
+          Vue.delete(Model.copiesById, k)
+        )
+      }
     },
 
     // Creates a copy of the record with the passed-in id, stores it in copiesById
@@ -322,15 +351,15 @@ export default function makeServiceMutations() {
     // Removes the copy from copiesById
     clearCopy(state, id) {
       const { keepCopiesInStore } = state
-      if (keepCopiesInStore) {
-        Vue.delete(state.copiesById, id)
-      } else {
-        const { serverAlias, servicePath } = state
-        const Model = _get(
-          models,
-          `[${serverAlias}].byServicePath[${servicePath}]`
-        )
-        Vue.delete(Model.copiesById, id)
+      const Model = _get(
+        models,
+        `[${state.serverAlias}].byServicePath[${state.servicePath}]`
+      )
+
+      const copiesById = keepCopiesInStore ? state.copiesById : Model.copiesById
+
+      if (copiesById[id]) {
+        Vue.delete(copiesById, id)
       }
     },
 

--- a/src/service-module/service-module.mutations.ts
+++ b/src/service-module/service-module.mutations.ts
@@ -235,7 +235,11 @@ export default function makeServiceMutations() {
         return map
       }, {})
 
-      const Model = _get(models, `[${state.serverAlias}][${state.modelName}]`)
+      const Model = _get(models, [
+        state.serverAlias,
+        'byServicePath',
+        state.servicePath
+      ])
       const copiesById = state.keepCopiesInStore
         ? state.copiesById
         : Model.copiesById
@@ -278,10 +282,11 @@ export default function makeServiceMutations() {
       if (state.keepCopiesInStore) {
         state.copiesById = {}
       } else {
-        const Model = _get(
-          models,
-          `[${state.serverAlias}].byServicePath[${state.servicePath}]`
-        )
+        const Model = _get(models, [
+          state.serverAlias,
+          'byServicePath',
+          state.servicePath
+        ])
         Object.keys(Model.copiesById).forEach(k =>
           Vue.delete(Model.copiesById, k)
         )
@@ -365,10 +370,11 @@ export default function makeServiceMutations() {
     // Removes the copy from copiesById
     clearCopy(state, id) {
       const { keepCopiesInStore } = state
-      const Model = _get(
-        models,
-        `[${state.serverAlias}].byServicePath[${state.servicePath}]`
-      )
+      const Model = _get(models, [
+        state.serverAlias,
+        'byServicePath',
+        state.servicePath
+      ])
 
       const copiesById = keepCopiesInStore ? state.copiesById : Model.copiesById
 

--- a/src/service-module/service-module.mutations.ts
+++ b/src/service-module/service-module.mutations.ts
@@ -253,13 +253,18 @@ export default function makeServiceMutations() {
         `[${serverAlias}].byServicePath[${servicePath}]`
       )
 
+      let item
+
       if (Model) {
-        var model = new Model(current, { clone: true })
+        item = new Model(current, { clone: true })
       } else {
-        var copyData = mergeWithAccessors({}, current)
+        const existingClone = state.copiesById[id]
+
+        item = existingClone
+          ? mergeWithAccessors(existingClone, current)
+          : mergeWithAccessors({}, current)
       }
 
-      let item = model || copyData
       if (keepCopiesInStore) {
         state.copiesById[id] = item
       } else {

--- a/src/service-module/service-module.mutations.ts
+++ b/src/service-module/service-module.mutations.ts
@@ -321,9 +321,17 @@ export default function makeServiceMutations() {
 
     // Removes the copy from copiesById
     clearCopy(state, id) {
-      const newCopiesById = Object.assign({}, state.copiesById)
-      delete newCopiesById[id]
-      state.copiesById = newCopiesById
+      const { keepCopiesInStore } = state
+      if (keepCopiesInStore) {
+        Vue.delete(state.copiesById, id)
+      } else {
+        const { serverAlias, servicePath } = state
+        const Model = _get(
+          models,
+          `[${serverAlias}].byServicePath[${servicePath}]`
+        )
+        Vue.delete(Model.copiesById, id)
+      }
     },
 
     /**

--- a/src/service-module/types.ts
+++ b/src/service-module/types.ts
@@ -50,6 +50,7 @@ export interface MakeServicePluginOptions {
   replaceItems?: boolean
   skipRequestIfExists?: boolean
   nameStyle?: string
+  keepCopiesInStore?: boolean
 
   servicePath?: string
   namespace?: string
@@ -245,7 +246,9 @@ export interface ModelStatic extends EventEmitter {
    * A proxy for the `find` getter
    * @param params Find params
    */
-  findInStore<M extends Model = Model>(params?: Params | Ref<Params>): Paginated<M>
+  findInStore<M extends Model = Model>(
+    params?: Params | Ref<Params>
+  ): Paginated<M>
 
   /**
    * A proxy for the `count` action
@@ -269,7 +272,10 @@ export interface ModelStatic extends EventEmitter {
    * @param id ID of record to retrieve
    * @param params Get params
    */
-  getFromStore<M extends Model = Model>(id: Id | Ref<Id>, params?: Params | Ref<Params>): M | undefined
+  getFromStore<M extends Model = Model>(
+    id: Id | Ref<Id>,
+    params?: Params | Ref<Params>
+  ): M | undefined
 }
 
 /** Model instance interface */

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -28,6 +28,8 @@ interface Params {
   provider?: string
   route?: { [key: string]: string }
   headers?: { [key: string]: any }
+  temps?: boolean
+  copies?: boolean
 
   [key: string]: any // (JL) not sure if we want this
 }
@@ -231,7 +233,6 @@ export function getId(item, idField) {
   if (item._id != null || item.hasOwnProperty('_id')) {
     return item._id
   }
-
 }
 
 // Creates a Model class name from the last part of the servicePath

--- a/test/make-find-mixin.test.ts
+++ b/test/make-find-mixin.test.ts
@@ -30,7 +30,7 @@ function makeContext() {
 Vue.use(Vuex)
 Vue.use(FeathersVuex)
 
-describe('Find Mixin', function() {
+describe('Find Mixin', function () {
   const { makeServicePlugin, FindModel } = makeContext()
   const serviceName = 'todos'
   const store = new Vuex.Store({
@@ -42,7 +42,7 @@ describe('Find Mixin', function() {
     ]
   })
 
-  it('correctly forms mixin data', function() {
+  it('correctly forms mixin data', function () {
     const todosMixin = makeFindMixin({ service: 'todos' })
     interface TodosComponent {
       todos: []
@@ -99,7 +99,7 @@ describe('Find Mixin', function() {
     )
   })
 
-  it('correctly forms mixin data for dynamic service', function() {
+  it('correctly forms mixin data for dynamic service', function () {
     const tasksMixin = makeFindMixin({
       service() {
         return this.serviceName

--- a/test/service-module/model-base.test.ts
+++ b/test/service-module/model-base.test.ts
@@ -18,8 +18,8 @@ Vue.use(Vuex)
 process.setMaxListeners(100)
 
 describe.skip('Model - Standalone', function () {
-  it.skip('allows using a model without a service', function () { })
-  it.skip('rename serverAlias to just `alias` or maybe `groupName`', function () { })
+  it.skip('allows using a model without a service', function () {})
+  it.skip('rename serverAlias to just `alias` or maybe `groupName`', function () {})
 })
 
 describe('makeModel / BaseModel', function () {
@@ -28,7 +28,7 @@ describe('makeModel / BaseModel', function () {
   })
 
   it('properly sets up the BaseModel', function () {
-    const alias = 'default'
+    const alias = 'model-base'
     const { BaseModel } = feathersVuex(feathers, { serverAlias: alias })
     const {
       name,
@@ -51,7 +51,7 @@ describe('makeModel / BaseModel', function () {
     assert(!preferUpdate, 'prefer fetch by default')
 
     // Readonly props
-    assert(serverAlias === 'default', 'serverAlias')
+    assert(serverAlias === 'model-base', 'serverAlias')
     assert(models, 'models are available')
     assert.equal(Object.keys(copiesById).length, 0, 'copiesById is empty')
 
@@ -88,14 +88,9 @@ describe('makeModel / BaseModel', function () {
     })
 
     // Utility Methods
-    const utilityMethods = [
-      'hydrateAll'
-    ]
+    const utilityMethods = ['hydrateAll']
     utilityMethods.forEach(method => {
-      assert(
-        typeof BaseModel[method] === 'function',
-        `has ${method} method`
-      )
+      assert(typeof BaseModel[method] === 'function', `has ${method} method`)
     })
 
     const eventMethods = [
@@ -108,10 +103,7 @@ describe('makeModel / BaseModel', function () {
       'removeAllListeners'
     ]
     eventMethods.forEach(method => {
-      assert(
-        typeof BaseModel[method] === 'function',
-        `has ${method} method`
-      )
+      assert(typeof BaseModel[method] === 'function', `has ${method} method`)
     })
   })
 
@@ -149,7 +141,7 @@ describe('makeModel / BaseModel', function () {
   })
 
   it('allows access to other models after Vuex plugins are registered', function () {
-    const serverAlias = 'default'
+    const serverAlias = 'model-base'
     const { makeServicePlugin, BaseModel, models } = feathersVuex(feathers, {
       idField: '_id',
       serverAlias
@@ -158,7 +150,7 @@ describe('makeModel / BaseModel', function () {
     // Create a Todo Model & Plugin
     class Todo extends BaseModel {
       public static modelName = 'Todo'
-      public test: boolean = true
+      public test = true
     }
     const todosPlugin = makeServicePlugin({
       servicePath: 'todos',
@@ -169,7 +161,7 @@ describe('makeModel / BaseModel', function () {
     // Create a Task Model & Plugin
     class Task extends BaseModel {
       public static modelName = 'Task'
-      public test: boolean = true
+      public test = true
     }
     const tasksPlugin = makeServicePlugin({
       servicePath: 'tasks',
@@ -196,7 +188,7 @@ describe('makeModel / BaseModel', function () {
     })
     class Todo extends myApi.BaseModel {
       public static modelName = 'Todo'
-      public test: boolean = true
+      public test = true
     }
     const todosPlugin = myApi.makeServicePlugin({
       Model: Todo,
@@ -210,7 +202,7 @@ describe('makeModel / BaseModel', function () {
     })
     class Task extends theirApi.BaseModel {
       public static modelName = 'Task'
-      public test: boolean = true
+      public test = true
     }
     const tasksPlugin = theirApi.makeServicePlugin({
       Model: Task,

--- a/test/service-module/model-methods.test.ts
+++ b/test/service-module/model-methods.test.ts
@@ -98,6 +98,14 @@ function makeContext() {
     }
   }
 
+  class Person extends BaseModel {
+    public static modelName = 'Person'
+    public static servicePath: 'persons'
+    public constructor(data?, options?) {
+      super(data, options)
+    }
+  }
+
   const store = new Vuex.Store<RootState>({
     strict: true,
     plugins: [
@@ -114,6 +122,12 @@ function makeContext() {
         Model: Letter,
         servicePath: 'letters',
         service: feathersClient.service('letters')
+      }),
+      makeServicePlugin({
+        Model: Person,
+        servicePath: 'persons',
+        service: feathersClient.service('persons'),
+        keepCopiesInStore: true
       })
     ]
   })
@@ -122,6 +136,7 @@ function makeContext() {
     Task,
     Todo,
     Letter,
+    Person,
     lettersService,
     store
   }
@@ -284,8 +299,38 @@ describe('Models - Methods', function () {
     assert(!store.state.tasks.tempsById[tempId], 'temp was removed')
   })
 
-  it.skip('instance.remove removes cloned records from the store', function () {})
-  it.skip('instance.remove removes cloned records from the Model.copiesById', function () {})
+  it.skip('instance.remove removes cloned records from the store', function () {
+    const { Person, store } = makeContext()
+    const person = new Person({ test: true })
+    const tempId = person.__id
+
+    person.clone()
+
+    // @ts-ignore
+    assert(store.state.persons.copiesById[tempId], 'clone exists')
+
+    person.remove()
+
+    // @ts-ignore
+    assert(!store.state.persons.copiesById[tempId], 'clone was removed')
+  })
+
+  it.skip('instance.remove removes cloned records from the Model.copiesById', function () {
+    const { Task, store } = makeContext()
+    const task = new Task({ test: true })
+    const tempId = task.__id
+
+    task.clone()
+
+    // @ts-ignore
+    assert(Task.copiesById[tempId], 'clone exists')
+
+    task.remove()
+
+    // @ts-ignore
+    assert(!Task.copiesById[tempId], 'clone was removed')
+  })
+
   it.skip('removes clone and original upon calling clone.remove()', function () {})
 
   it('instance methods still available in store data after updateItem mutation (or socket event)', async function () {

--- a/test/service-module/model-methods.test.ts
+++ b/test/service-module/model-methods.test.ts
@@ -23,8 +23,9 @@ interface TodoState extends ServiceState {
   isTrue: boolean
 }
 interface RootState {
-  todos: TodoState
-  tasks: ServiceState
+  ['model-methods-persons']: ServiceState
+  ['model-methods-todos']: TodoState
+  ['model-methods-tasks']: ServiceState
   tests: ServiceState
   blah: ServiceState
   things: ServiceState
@@ -42,9 +43,9 @@ function makeContext() {
     context.result = JSON.parse(JSON.stringify(context.result))
   }
 
-  feathersClient.use('letters', memory())
+  feathersClient.use('model-methods-letters', memory())
 
-  const lettersService = feathersClient.service('letters')
+  const lettersService = feathersClient.service('model-methods-letters')
 
   // Setup hooks on letters service to simulate toJSON serialization that occurs
   // with a remote API request.
@@ -63,14 +64,14 @@ function makeContext() {
 
   class Task extends BaseModel {
     public static modelName = 'Task'
-    public static servicePath: 'tasks'
+    public static servicePath: 'model-methods-tasks'
     public constructor(data?, options?) {
       super(data, options)
     }
   }
   class Todo extends BaseModel {
     public static modelName = 'Todo'
-    public static servicePath: 'todos'
+    public static servicePath: 'model-methods-todos'
     public constructor(data?, options?) {
       super(data, options)
     }
@@ -81,6 +82,7 @@ function makeContext() {
       super(data, options)
     }
     public static modelName = 'Letter'
+    public static servicePath = 'model-methods-letters'
     public static instanceDefaults(data, { models, store }) {
       return {
         to: '',
@@ -100,7 +102,7 @@ function makeContext() {
 
   class Person extends BaseModel {
     public static modelName = 'Person'
-    public static servicePath: 'persons'
+    public static servicePath = 'model-methods-persons'
     public constructor(data?, options?) {
       super(data, options)
     }
@@ -111,26 +113,101 @@ function makeContext() {
     plugins: [
       makeServicePlugin({
         Model: Task,
-        service: feathersClient.service('tasks'),
-        preferUpdate: true
+        servicePath: 'model-methods-tasks',
+        service: feathersClient.service('model-methods-tasks'),
+        preferUpdate: true,
+        namespace: 'model-methods-tasks'
       }),
       makeServicePlugin({
         Model: Todo,
-        service: feathersClient.service('todos')
+        servicePath: 'model-methods-todos',
+        service: feathersClient.service('model-methods-todos'),
+        namespace: 'model-methods-todos'
       }),
       makeServicePlugin({
         Model: Letter,
-        servicePath: 'letters',
-        service: feathersClient.service('letters')
+        servicePath: 'model-methods-letters',
+        service: feathersClient.service('model-methods-letters'),
+        namespace: 'model-methods-letters'
       }),
       makeServicePlugin({
         Model: Person,
-        servicePath: 'persons',
-        service: feathersClient.service('persons'),
-        keepCopiesInStore: true
+        servicePath: 'model-methods-persons',
+        service: feathersClient.service('model-methods-persons'),
+        keepCopiesInStore: true,
+        namespace: 'model-methods-persons'
       })
     ]
   })
+
+  // Fake server call
+  feathersClient.service('model-methods-tasks').hooks({
+    before: {
+      create: [
+        context => {
+          delete context.data.__id
+          delete context.data.__isTemp
+        },
+        context => {
+          context.result = { _id: 24, ...context.data }
+          return context
+        }
+      ],
+      update: [
+        context => {
+          context.result = { ...context.data }
+          return context
+        }
+      ],
+      patch: [
+        context => {
+          context.result = { ...context.data }
+          return context
+        }
+      ],
+      remove: [
+        context => {
+          context.result = {}
+          return context
+        }
+      ]
+    }
+  })
+
+  // Fake server call
+  feathersClient.service('model-methods-persons').hooks({
+    before: {
+      create: [
+        context => {
+          delete context.data.__id
+          delete context.data.__isTemp
+        },
+        context => {
+          context.result = { _id: 24, ...context.data }
+          return context
+        }
+      ],
+      update: [
+        context => {
+          context.result = { ...context.data }
+          return context
+        }
+      ],
+      patch: [
+        context => {
+          context.result = { ...context.data }
+          return context
+        }
+      ],
+      remove: [
+        context => {
+          context.result = {}
+          return context
+        }
+      ]
+    }
+  })
+
   return {
     BaseModel,
     Task,
@@ -295,43 +372,94 @@ describe('Models - Methods', function () {
 
     task.remove()
 
-    // @ts-ignore
-    assert(!store.state.tasks.tempsById[tempId], 'temp was removed')
+    assert(
+      !store.state['model-methods-tasks'].tempsById[tempId],
+      'temp was removed'
+    )
   })
 
-  it.skip('instance.remove removes cloned records from the store', function () {
+  it('instance.remove removes cloned record from the store', async function () {
+    const { Person, store } = makeContext()
+    const person = new Person({ _id: 1, test: true })
+    const id = person._id
+
+    // @ts-ignore
+    const { copiesById } = store.state['model-methods-persons']
+
+    person.clone()
+
+    assert(copiesById[id], 'clone exists')
+
+    await person.remove()
+
+    assert(!copiesById[id], 'clone was removed')
+  })
+
+  it('instance.remove removes cloned record from Model.copiesById', async function () {
+    const { Task } = makeContext()
+    const task = new Task({ _id: 2, test: true })
+    const id = task._id
+
+    task.clone()
+
+    assert(Task.copiesById[id], 'clone exists')
+
+    await task.remove()
+
+    assert(!Task.copiesById[id], 'clone was removed')
+  })
+
+  it('instance.remove for temp record removes cloned record from the store', function () {
     const { Person, store } = makeContext()
     const person = new Person({ test: true })
     const tempId = person.__id
 
+    // @ts-ignore
+    const { copiesById } = store.state['model-methods-persons']
+
     person.clone()
 
-    // @ts-ignore
-    assert(store.state.persons.copiesById[tempId], 'clone exists')
+    assert(copiesById[tempId], 'clone exists')
 
     person.remove()
 
-    // @ts-ignore
-    assert(!store.state.persons.copiesById[tempId], 'clone was removed')
+    assert(!copiesById[tempId], 'clone was removed')
   })
 
-  it.skip('instance.remove removes cloned records from the Model.copiesById', function () {
-    const { Task, store } = makeContext()
+  it('instance.remove for temp record removes cloned record from the Model.copiesById', function () {
+    const { Task } = makeContext()
     const task = new Task({ test: true })
     const tempId = task.__id
 
     task.clone()
 
-    // @ts-ignore
     assert(Task.copiesById[tempId], 'clone exists')
 
     task.remove()
 
-    // @ts-ignore
     assert(!Task.copiesById[tempId], 'clone was removed')
   })
 
-  it.skip('removes clone and original upon calling clone.remove()', function () {})
+  it('removes clone and original upon calling clone.remove()', async function () {
+    const { Person, store } = makeContext()
+    const person = new Person({ _id: 1, test: true })
+    const id = person._id
+
+    // @ts-ignore
+    const { copiesById, keyedById } = store.state['model-methods-persons']
+
+    person.clone()
+
+    assert(copiesById[id], 'clone exists')
+    assert(keyedById[id], 'original exists')
+
+    const clone = copiesById[id]
+
+    await clone.remove()
+
+    assert(!copiesById[id], 'clone was removed')
+    assert(!keyedById[id], 'original was removed')
+  })
 
   it('instance methods still available in store data after updateItem mutation (or socket event)', async function () {
     const { Letter, store, lettersService } = makeContext()
@@ -345,7 +473,7 @@ describe('Models - Methods', function () {
       'saved instance has a save method'
     )
 
-    store.commit('letters/updateItem', {
+    store.commit('model-methods-letters/updateItem', {
       id: letter.id,
       name: 'Garmadon / Dad',
       age: 1026

--- a/test/service-module/model-temp-ids.test.ts
+++ b/test/service-module/model-temp-ids.test.ts
@@ -42,11 +42,11 @@ function makeContext() {
     new ComicService({ store: makeStore() })
   )
   const { makeServicePlugin, BaseModel } = feathersVuex(feathersClient, {
-    serverAlias: 'default'
+    serverAlias: 'model-temp-ids'
   })
   class Comic extends BaseModel {
     public static modelName = 'Comic'
-    public static test: boolean = true
+    public static test = true
 
     public constructor(data, options?) {
       super(data, options)
@@ -70,12 +70,12 @@ function makeContext() {
   }
 }
 
-describe('Models - Temp Ids', function() {
+describe('Models - Temp Ids', function () {
   beforeEach(() => {
     clearModels()
   })
 
-  it('adds tempIds for items without an [idField]', function() {
+  it('adds tempIds for items without an [idField]', function () {
     const { makeServicePlugin, BaseModel } = feathersVuex(feathersClient, {
       idField: '_id',
       serverAlias: 'temp-ids'
@@ -109,7 +109,7 @@ describe('Models - Temp Ids', function() {
     assert(desc.enumerable, 'it is enumerable')
   })
 
-  it('allows specifying the value for the tempId', function() {
+  it('allows specifying the value for the tempId', function () {
     const context = makeContext()
     const Comic = context.Comic
     const oid = new ObjectID().toHexString()
@@ -120,7 +120,7 @@ describe('Models - Temp Ids', function() {
     assert.equal(comic.__id, oid, 'the objectid was used')
   })
 
-  it('adds to state.tempsById', function() {
+  it('adds to state.tempsById', function () {
     const { makeServicePlugin, BaseModel } = feathersVuex(feathersClient, {
       idField: '_id',
       serverAlias: 'temp-ids'
@@ -151,7 +151,7 @@ describe('Models - Temp Ids', function() {
     assert(store.state.transactions.tempsById[txn.__id], 'it is in the store')
   })
 
-  it('maintains reference to temp item after save', function() {
+  it('maintains reference to temp item after save', function () {
     const { makeServicePlugin, BaseModel } = feathersVuex(feathersClient, {
       idField: '_id',
       serverAlias: 'temp-ids'
@@ -216,7 +216,7 @@ describe('Models - Temp Ids', function() {
     })
   })
 
-  it('removes uncreated temp', function() {
+  it('removes uncreated temp', function () {
     const { makeServicePlugin, BaseModel } = feathersVuex(feathersClient, {
       idField: '_id',
       serverAlias: 'temp-ids'
@@ -250,7 +250,7 @@ describe('Models - Temp Ids', function() {
     assert(!store.state.things.tempsById[thing.__id], 'temp item was removed')
   })
 
-  it('clones into Model.copiesById', function() {
+  it('clones into Model.copiesById', function () {
     const { makeServicePlugin, BaseModel } = feathersVuex(feathersClient, {
       idField: '_id',
       serverAlias: 'temp-ids'
@@ -281,7 +281,7 @@ describe('Models - Temp Ids', function() {
     assert(Transaction.copiesById[txn.__id], 'it is in the copiesById')
   })
 
-  it('commits into store.tempsById', function() {
+  it('commits into store.tempsById', function () {
     const { makeServicePlugin, BaseModel } = feathersVuex(feathersClient, {
       idField: '_id',
       serverAlias: 'temp-ids'
@@ -316,7 +316,7 @@ describe('Models - Temp Ids', function() {
     assert.equal(originalTemp.amount, 11.99, 'original was updated')
   })
 
-  it('can reset a temp clone', function() {
+  it('can reset a temp clone', function () {
     const { makeServicePlugin, BaseModel } = feathersVuex(feathersClient, {
       serverAlias: 'temp-ids'
     })
@@ -348,7 +348,7 @@ describe('Models - Temp Ids', function() {
     assert.equal(clone.amount, 1.99, 'clone was reset')
   })
 
-  it('returns the keyedById record after create, not the tempsById record', function(done) {
+  it('returns the keyedById record after create, not the tempsById record', function (done) {
     const { Comic, store } = makeContext()
 
     const comic = new Comic({
@@ -377,7 +377,7 @@ describe('Models - Temp Ids', function() {
       .catch(done)
   })
 
-  it('removes __isTemp from temp and clone', function() {
+  it('removes __isTemp from temp and clone', function () {
     const { makeServicePlugin, BaseModel } = feathersVuex(feathersClient, {
       idField: '_id',
       serverAlias: 'temp-ids'
@@ -406,7 +406,7 @@ describe('Models - Temp Ids', function() {
     assert(!clone.hasOwnProperty('__isTemp'), '__isTemp was removed from clone')
   })
 
-  it('updateTemp assigns ID to temp and migrates it from tempsById to keyedById', function() {
+  it('updateTemp assigns ID to temp and migrates it from tempsById to keyedById', function () {
     const { makeServicePlugin, BaseModel } = feathersVuex(feathersClient, {
       idField: '_id',
       serverAlias: 'temp-ids'
@@ -438,7 +438,7 @@ describe('Models - Temp Ids', function() {
     )
   })
 
-  it('Clone gets _id after save (create only called once)', async function() {
+  it('Clone gets _id after save (create only called once)', async function () {
     // Test ensures subsequent calls to clone.save() do not call create
     const { makeServicePlugin, BaseModel } = feathersVuex(feathersClient, {
       idField: '_id',
@@ -510,7 +510,7 @@ describe('Models - Temp Ids', function() {
     assert(thing.description === 'Thing 3', "thing got clone's new changes")
   })
 
-  it('find() getter does not return duplicates with temps: true', async function() {
+  it('find() getter does not return duplicates with temps: true', async function () {
     const { makeServicePlugin, BaseModel } = feathersVuex(feathersClient, {
       idField: '_id',
       serverAlias: 'temp-ids'

--- a/test/service-module/module.getters.test.ts
+++ b/test/service-module/module.getters.test.ts
@@ -12,6 +12,8 @@ import {
   clearModels
 } from '../../src/service-module/global-models'
 
+import { values as _values } from 'lodash'
+
 const options = {
   idField: '_id',
   tempIdField: '__id',
@@ -81,10 +83,9 @@ describe('Service Module - Getters', function () {
         1: { test: true }
       }
     }
-    // @ts-ignore
+
     const result = getCopyById(state)(1)
 
-    // @ts-ignore
     assert(result.test, 'got the copy')
   })
 
@@ -92,13 +93,10 @@ describe('Service Module - Getters', function () {
     const state = {
       keepCopiesInStore: false,
       servicePath: 'todos',
-      serverAlias: 'my-getters-test',
-      copiesById: {
-        1: { test: true }
-      }
+      serverAlias: 'my-getters-test'
     }
     Object.assign(globalModels, {
-      'my-getters-test': {
+      [state.serverAlias]: {
         byServicePath: {
           todos: {
             copiesById: {
@@ -108,10 +106,9 @@ describe('Service Module - Getters', function () {
         }
       }
     })
-    // @ts-ignore
+
     const result = getCopyById(state)(1)
 
-    // @ts-ignore
     assert(result.test, 'got the copy')
 
     clearModels()
@@ -119,20 +116,18 @@ describe('Service Module - Getters', function () {
 
   it('get works on keyedById', function () {
     const { state, items } = this
-    // @ts-ignore
+
     const result = get(state)(1)
 
-    // @ts-ignore
     assert.deepEqual(result, items[0])
   })
 
   it('get works on tempsById', function () {
     const { state } = this
     const tempId = Object.keys(state.tempsById)[0]
-    // @ts-ignore
+
     const result = get(state)(tempId)
 
-    // @ts-ignore
     assert(result.__id === tempId)
   })
 
@@ -161,6 +156,162 @@ describe('Service Module - Getters', function () {
     assert(results.limit === 0, 'limit was correct')
     assert(results.skip === 0, 'skip was correct')
     assert(results.total === 4, 'total was correct')
+  })
+
+  it('find - no copies by default', function () {
+    const state = {
+      keepCopiesInStore: false,
+      servicePath: 'todos',
+      serverAlias: 'my-getters-test',
+      keyedById: {
+        1: { _id: 1, test: true, __isClone: false },
+        2: { _id: 2, test: true, __isClone: false },
+        3: { _id: 3, test: true, __isClone: false }
+      },
+      copiesById: {
+        1: { _id: 1, test: true, __isClone: true }
+      }
+    }
+    Object.assign(globalModels, {
+      [state.serverAlias]: {
+        byServicePath: {
+          todos: {
+            copiesById: {
+              1: { _id: 1, test: true, __isClone: true }
+            }
+          }
+        }
+      }
+    })
+
+    const params = { query: {} }
+    const results = find(state)(params)
+
+    assert.deepEqual(
+      results.data,
+      _values(state.keyedById).filter(i => !i.__isClone),
+      'the list was correct'
+    )
+    assert(results.limit === 0, 'limit was correct')
+    assert(results.skip === 0, 'skip was correct')
+    assert(results.total === 3, 'total was correct')
+
+    clearModels()
+  })
+
+  it('find - with copies with keepCopiesInStore:true', function () {
+    const state = {
+      keepCopiesInStore: true,
+      idField: '_id',
+      keyedById: {
+        1: { _id: 1, test: true, __isClone: false },
+        2: { _id: 2, test: true, __isClone: false },
+        3: { _id: 3, test: true, __isClone: false }
+      },
+      copiesById: {
+        1: { _id: 1, test: true, __isClone: true }
+      }
+    }
+
+    const params = { query: {}, copies: true }
+    const results = find(state)(params)
+
+    const expected = [
+      { _id: 1, test: true, __isClone: true },
+      { _id: 2, test: true, __isClone: false },
+      { _id: 3, test: true, __isClone: false }
+    ]
+
+    assert.deepEqual(results.data, expected, 'the list was correct')
+    assert(results.limit === 0, 'limit was correct')
+    assert(results.skip === 0, 'skip was correct')
+    assert(results.total === 3, 'total was correct')
+  })
+
+  it('find - with copies with keepCopiesInStore:false', function () {
+    const state = {
+      keepCopiesInStore: false,
+      servicePath: 'todos',
+      serverAlias: 'my-getters-test',
+      idField: '_id',
+      keyedById: {
+        1: { _id: 1, test: true, __isClone: false },
+        2: { _id: 2, test: true, __isClone: false },
+        3: { _id: 3, test: true, __isClone: false }
+      }
+    }
+    Object.assign(globalModels, {
+      [state.serverAlias]: {
+        byServicePath: {
+          todos: {
+            copiesById: {
+              1: { _id: 1, test: true, __isClone: true }
+            }
+          }
+        }
+      }
+    })
+
+    const params = { query: {}, copies: true }
+    const results = find(state)(params)
+
+    const expected = [
+      { _id: 1, test: true, __isClone: true },
+      { _id: 2, test: true, __isClone: false },
+      { _id: 3, test: true, __isClone: false }
+    ]
+
+    assert.deepEqual(results.data, expected, 'the list was correct')
+    assert(results.limit === 0, 'limit was correct')
+    assert(results.skip === 0, 'skip was correct')
+    assert(results.total === 3, 'total was correct')
+
+    clearModels()
+  })
+
+  it('find - with copies and temps', function () {
+    const state = {
+      keepCopiesInStore: false,
+      servicePath: 'todos',
+      serverAlias: 'my-getters-test',
+      idField: '_id',
+      keyedById: {
+        1: { _id: 1, test: true, __isClone: false },
+        2: { _id: 2, test: true, __isClone: false },
+        3: { _id: 3, test: true, __isClone: false }
+      },
+      tempsById: {
+        abc: { __id: 'abc', test: true, __isClone: false, __isTemp: true }
+      }
+    }
+    Object.assign(globalModels, {
+      [state.serverAlias]: {
+        byServicePath: {
+          todos: {
+            copiesById: {
+              1: { _id: 1, test: true, __isClone: true }
+            }
+          }
+        }
+      }
+    })
+
+    const params = { query: {}, copies: true, temps: true }
+    const results = find(state)(params)
+
+    const expected = [
+      { _id: 1, test: true, __isClone: true },
+      { _id: 2, test: true, __isClone: false },
+      { _id: 3, test: true, __isClone: false },
+      { __id: 'abc', test: true, __isClone: false, __isTemp: true }
+    ]
+
+    assert.deepEqual(results.data, expected, 'the list was correct')
+    assert(results.limit === 0, 'limit was correct')
+    assert(results.skip === 0, 'skip was correct')
+    assert(results.total === 4, 'total was correct')
+
+    clearModels()
   })
 
   it('find with query', function () {

--- a/test/service-module/service-module.actions.test.ts
+++ b/test/service-module/service-module.actions.test.ts
@@ -75,7 +75,7 @@ function makeContext() {
   })
 
   const { makeServicePlugin, BaseModel } = feathersVuex(feathersClient, {
-    serverAlias: 'default'
+    serverAlias: 'service-module-actions'
   })
   class Todo extends BaseModel {
     public static modelName = 'Todo'

--- a/test/service-module/service-module.getters.test.ts
+++ b/test/service-module/service-module.getters.test.ts
@@ -18,7 +18,7 @@ const options = {
   idField: '_id',
   tempIdField: '__id',
   autoRemove: false,
-  serverAlias: 'default',
+  serverAlias: 'service-module-getters',
   Model: null,
   service: null
 }

--- a/test/service-module/service-module.mutations.test.ts
+++ b/test/service-module/service-module.mutations.test.ts
@@ -1169,13 +1169,36 @@ describe('Service Module - Mutations', function () {
 
       const item1 = {
         _id: 1,
-        test: true /*,
+        test: true
+      }
+      store.commit('comics/addItem', item1)
+
+      // Create a copy and modify it.
+      store.commit('comics/createCopy', item1._id)
+      const copy = Comic.copiesById[item1._id]
+      copy.test = false
+
+      // Call resetCopy and check that it's back to the original value
+      store.commit('comics/resetCopy', item1._id)
+
+      assert(copy.test === true, 'the copy was reset')
+
+      clearModels()
+    })
+
+    it.skip('resetCopy with keepCopiesInStore: false and with intact getter/setter', function () {
+      const context = makeContext()
+      const { Comic, store } = context
+
+      const item1 = {
+        _id: 1,
+        test: true,
         get getter() {
           return 'Life is a Joy!'
         },
         set setter(val) {
           this.test = val
-        }*/
+        }
       }
       store.commit('comics/addItem', item1)
 
@@ -1190,9 +1213,9 @@ describe('Service Module - Mutations', function () {
       assert(copy.test === true, 'the copy was reset')
 
       // Make sure accessors stayed intact
-      //assertGetter(copy, 'getter', 'Life is a Joy!')
-      //copy.setter = false
-      //assert(copy.test === false, 'the setter is intact')
+      assertGetter(copy, 'getter', 'Life is a Joy!')
+      copy.setter = false
+      assert(copy.test === false, 'the setter is intact')
 
       clearModels()
     })


### PR DESCRIPTION
### ❗ Problem:

I have a UI-table for data manipulation. I use this table somehow like the `FeathersVuexFormWrapper` but for multiple items at once. I implemented a cancel/save mechanism for the whole table and all displayed items.
So I create clones for existing items and show the clones in the table for manipulation. When I add a temp record I also concat them to the table. I implemented it by querying the original and temp records and replace the resulting items with existing clones afterwards

### ✔️ Solution:
An additional `copies` property in `params` for getters would make this shorter. I think this could become useful for someone else so here is the change for this with tests and docs. Just pass `{ query: {}, copies: true }` to activate this behaviour. By this the original and temp items get queried normally and then get replaced with the according clones. ✔️ 

### Other things:

While programming this I came accross some other issues:
1. `values = values.concat(_.values())` in the find-getter is slow. `values.push(..._.values()` is much more performant. See https://dev.to/uilicious/javascript-array-push-is-945x-faster-than-array-concat-1oki. This optimization is only relevant for `temps: true` but since the `find` getter is used anywhere small performance changes can make a difference ✔️ 
2. The `clearCopy` mutation was not working with `Model.copiesById`. ✔️ 
3. The `createCopy` mutation was not working properly for `state.copiesById` when cloning an item twice. ✔️ 
4. I added mutation-tests for the `copy` mutations for `Model.copiesById` / `keepCopiesById: false` . But there was a problem with the getter / setter which got undefined with `mergeWithAccessor`. I could not solve this problem. 😕 
5. I wrote tests for `it.skip('instance.remove removes cloned records from the store', function () {})` and `it.skip('instance.remove removes cloned records from the Model.copiesById', function () {})` but kept them as `it.skip` because I don't know whether you want to implement this, or not @marshallswain. See the discussion below: ❓ 

### ❓ Discussion:

There are some things I'm not sure how it should be. At the moment `copiesById` can get poluted because it never releases items (just by `clearCopy` which never gets called):
a. `removeItem` / `Model.remove` should delete the item from `copiesById`, as it is suggested in the tests? 💯 
b. `resetCopy` / `Model.reset` should delete the item from `copiesById`, shouldn't it? 💯 
c. ``commitCopy` / `Model.commit` should also delete the item from `copiesById`, right? I'm not that sure about this one. 😕 
d. `clearAll` mutation should also clear `copiesById`, shouldn't it? 💯 

@marshallswain For the last four questions I need your thoughts, please. As always I'm happy to contribute. Just a 'yes' or 'no' would be enough and I will implement them. 👍 