### PR TITLE
Add more insightful error messages for useFind and useGet

### DIFF
--- a/src/useFind.ts
+++ b/src/useFind.ts
@@ -66,6 +66,10 @@ export default function find<M extends Model = Model>(options: UseFindOptions): 
     options
   )
 
+  if (!model) {
+    throw new Error('No model provided for useFind(). Did you define and register it with FeathersVuex?')
+  }
+
   const getFetchParams = (providedParams?: Params | Ref<Params>): Params => {
     const provided = unwrapParams(providedParams)
 

--- a/src/useFind.ts
+++ b/src/useFind.ts
@@ -67,7 +67,9 @@ export default function find<M extends Model = Model>(options: UseFindOptions): 
   )
 
   if (!model) {
-    throw new Error('No model provided for useFind(). Did you define and register it with FeathersVuex?')
+    throw new Error(
+      `No model provided for useFind(). Did you define and register it with FeathersVuex?`
+    )
   }
 
   const getFetchParams = (providedParams?: Params | Ref<Params>): Params => {

--- a/src/useGet.ts
+++ b/src/useGet.ts
@@ -55,7 +55,9 @@ export default function get<M extends Model = Model>(options: UseGetOptions): Us
   )
 
   if (!model) {
-    throw new Error('No model provided for useGet(). Did you define and register it with FeathersVuex?')
+    throw new Error(
+      `No model provided for useGet(). Did you define and register it with FeathersVuex?`
+    )
   }
 
   function getId(): null | string | number {

--- a/src/useGet.ts
+++ b/src/useGet.ts
@@ -54,6 +54,10 @@ export default function get<M extends Model = Model>(options: UseGetOptions): Us
     options
   )
 
+  if (!model) {
+    throw new Error('No model provided for useGet(). Did you define and register it with FeathersVuex?')
+  }
+
   function getId(): null | string | number {
     return isRef(id) ? id.value : id || null
   }


### PR DESCRIPTION
Had some trouble where I was passing in undefined models into useGet(), the error message produced had me scratching my head for a few moments.

![image](https://user-images.githubusercontent.com/4034561/95812452-1c4e3700-0d1e-11eb-8c5d-8d35c44e08e4.png)

This PR add a handler for both `useGet()` and `useFind()` that'll produce a slightly more useful error message when no model is passed:

![image](https://user-images.githubusercontent.com/4034561/95812717-adbda900-0d1e-11eb-9b5b-4ab21ebcf06d.png)

This should hopefully save someone out there from a moment of confusion! 😅

---

Somewhat unrelated to this PR; as it is the month of [Hacktoberfest](https://hacktoberfest.digitalocean.com/) you should consider adding the `hacktoberfest` topic to this repository so that contributors can find and get a +1 for their contributions to FeathersVuex. 🙌