### PR TITLE
skip patch on empty data

### DIFF
--- a/src/service-module/service-module.actions.ts
+++ b/src/service-module/service-module.actions.ts
@@ -173,6 +173,11 @@ export default function makeServiceActions(service: Service<any>) {
       if (params && params.data) {
         data = params.data
       }
+      
+      if (Object.keys(data).length === 0 && data.constructor === Object) {
+        // skip request if empty data
+        return Promise.resolve(state.keyedById[id])
+      }
 
       return service
         .patch(id, data, params)


### PR DESCRIPTION
In my application I use `diffOnPatch` which returns an empty object if it found no differences. In this case the patch request to the server can be skipped.