### PR TITLE
Replace all hyphen characters

### DIFF
--- a/src/make-find-mixin.ts
+++ b/src/make-find-mixin.ts
@@ -45,7 +45,7 @@ export default function makeFindMixin(options) {
     name = 'service'
   }
 
-  const nameToUse = (name || service).replace('-', '_')
+  const nameToUse = (name || service).replace(/-/g, '_')
   const prefix = getServicePrefix(nameToUse)
   const capitalized = getServiceCapitalization(nameToUse)
   const SERVICE_NAME = `${prefix}ServiceName`

--- a/src/make-get-mixin.ts
+++ b/src/make-get-mixin.ts
@@ -38,7 +38,7 @@ export default function makeFindMixin(options) {
     name = 'service'
   }
 
-  const nameToUse = (name || service).replace('-', '_')
+  const nameToUse = (name || service).replace(/-/g, '_')
   const singularized = inflection.singularize(nameToUse)
   const prefix = inflection.camelize(singularized, true)
   const capitalized = prefix.charAt(0).toUpperCase() + prefix.slice(1)

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -274,7 +274,7 @@ export function getServicePrefix(servicePath) {
   const parts = servicePath.split('/')
   let name = parts[parts.length - 1]
   // name = inflection.underscore(name)
-  name = name.replace('-', '_')
+  name = name.replace(/-/g, '_')
   name = inflection.camelize(name, true)
   return name
 }
@@ -283,7 +283,7 @@ export function getServiceCapitalization(servicePath) {
   const parts = servicePath.split('/')
   let name = parts[parts.length - 1]
   // name = inflection.underscore(name)
-  name = name.replace('-', '_')
+  name = name.replace(/-/g, '_')
   name = inflection.camelize(name)
   return name
 }

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -162,7 +162,8 @@ describe('Utils', function () {
         ['environment-Panos', 'environmentPanos'],
         ['env-panos', 'envPanos'],
         ['envPanos', 'envPanos'],
-        ['api/v1/env-panos', 'envPanos']
+        ['api/v1/env-panos', 'envPanos'],
+        ['very-long-service', 'veryLongService']
       ]
       decisionTable.forEach(([path, prefix]) => {
         assert(
@@ -181,7 +182,8 @@ describe('Utils', function () {
         ['environment-Panos', 'EnvironmentPanos'],
         ['env-panos', 'EnvPanos'],
         ['envPanos', 'EnvPanos'],
-        ['api/v1/env-panos', 'EnvPanos']
+        ['api/v1/env-panos', 'EnvPanos'],
+        ['very-long-service', 'VeryLongService']
       ]
       decisionTable.forEach(([path, prefix]) => {
         assert(


### PR DESCRIPTION
### Summary

When using a Feathers service name with more than one hyphen character, feathers-vuex mixins no longer works when generating computed properties names and so on.

The current code only replace the first hyphen character.

This is a fix to replace all hyphen characters.