### PR TITLE
FIX Can't call update when id is 0

### DIFF
--- a/src/service-module/make-base-model.ts
+++ b/src/service-module/make-base-model.ts
@@ -421,7 +421,7 @@ export default function makeBaseModel(options: FeathersVuexOptions) {
       const { idField, _dispatch } = this.constructor as typeof BaseModel
       const id = getId(this, idField)
 
-      if (!id) {
+      if (id !== 0 && !id) {
         const error = new Error(
           `Missing ${idField} property. You must create the data before you can update with this data`
         )


### PR DESCRIPTION
Fix for Databases that use numbers as ID's and model's with number id 0 should be able to call the function 'update'.

#565 