### PR TITLE
fix: support client side initAuth

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -163,13 +163,18 @@ export const initAuth = function initAuth(options) {
       'You must pass the `commit` function in the `initAuth` function options.'
     )
   }
-  if (!req) {
+  let cookies
+  if (req) {
+    cookies = req.headers.cookie
+  } else if (document && document.cookie) {
+    cookies = document.cookie
+  } else {
     throw new Error(
       'You must pass the `req` object in the `initAuth` function options.'
     )
   }
 
-  const accessToken = readCookie(req.headers.cookie, cookieName)
+  const accessToken = readCookie(cookies, cookieName)
   const payload = getValidPayloadFromToken(accessToken)
 
   if (payload) {


### PR DESCRIPTION
You can use this version with ssr: false

Original ssr version from docs:
```
export const actions = {
  nuxtServerInit ({ commit, dispatch }, { req }) {
    return initAuth({
      commit,
      dispatch,
      req,
      moduleName: 'auth',
      cookieName: 'feathers-jwt'
    })
  },
  nuxtClientInit ({ state, dispatch, commit }, context) {
    // Run the authentication with the access token hydrated from the server store
    if (state.auth.accessToken) {
      return dispatch('auth/onInitAuth', state.auth.payload)
    }
  }
}
```
You can use the new version for client side only also:
```
export const actions = {
  nuxtClientInit ({ state, dispatch, commit }, context) {
    // Run the authentication without server side hydration
    initAuth({
      commit,
      dispatch,
      moduleName: 'auth',
      cookieName: 'feathers-jwt'
    }).then(()=> {
      if (state.auth.accessToken) {
        return dispatch('auth/onInitAuth', state.auth.payload)
      }      
    })
  }
}
```